### PR TITLE
Add web UI for fleet monitoring

### DIFF
--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -22,9 +22,10 @@ func main() {
 }
 
 var (
-	verbose bool
-	debug   bool
-	seed    int64
+	verbose   bool
+	debug     bool
+	seed      int64
+	keepAlive bool
 )
 
 var rootCmd = &cobra.Command{
@@ -84,6 +85,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug output")
 
 	runCmd.Flags().Int64Var(&seed, "seed", 0, "Random seed for reproducible stress tests (0 = random)")
+	runCmd.Flags().BoolVar(&keepAlive, "keep-alive", false, "Keep server running after scenario completes")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(interactiveCmd)
@@ -152,6 +154,10 @@ func runScenario(cmd *cobra.Command, args []string) error {
 	// Create runner with options
 	opts := []simulator.RunnerOption{
 		simulator.WithLogger(logger),
+	}
+
+	if keepAlive {
+		opts = append(opts, simulator.WithWaitForCancel())
 	}
 
 	// Use seed from flag or scenario

--- a/pkg/simulator/runner.go
+++ b/pkg/simulator/runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/NavarchProject/navarch/pkg/clock"
 	"github.com/NavarchProject/navarch/pkg/controlplane"
 	"github.com/NavarchProject/navarch/pkg/controlplane/db"
+	"github.com/NavarchProject/navarch/pkg/ui"
 	pb "github.com/NavarchProject/navarch/proto"
 	"github.com/NavarchProject/navarch/proto/protoconnect"
 )
@@ -483,6 +484,13 @@ func (r *Runner) startControlPlane(ctx context.Context) error {
 	mux := http.NewServeMux()
 	path, handler := protoconnect.NewControlPlaneServiceHandler(r.cpServer)
 	mux.Handle(path, handler)
+
+	// Register web UI
+	uiHandler, err := ui.NewHandler(r.database, r.logger.With(slog.String("component", "ui")))
+	if err != nil {
+		return fmt.Errorf("failed to initialize UI handler: %w", err)
+	}
+	uiHandler.RegisterRoutes(mux)
 
 	// Use port 8080 by default for interactive mode, otherwise random port
 	listenAddr := ":8080"

--- a/pkg/ui/handler.go
+++ b/pkg/ui/handler.go
@@ -1,0 +1,439 @@
+package ui
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/NavarchProject/navarch/pkg/controlplane/db"
+	pb "github.com/NavarchProject/navarch/proto"
+)
+
+//go:embed templates/*.html static/*.css
+var content embed.FS
+
+// Handler serves the web UI for fleet monitoring.
+type Handler struct {
+	db        db.DB
+	templates *template.Template
+	logger    *slog.Logger
+}
+
+// NewHandler creates a new UI handler.
+func NewHandler(database db.DB, logger *slog.Logger) (*Handler, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	funcMap := template.FuncMap{
+		"statusClass":       statusClass,
+		"healthClass":       healthClass,
+		"instanceStateClass": instanceStateClass,
+		"formatTime":        formatTime,
+		"formatDuration":    formatDuration,
+		"statusName":        statusName,
+		"healthName":        healthName,
+		"instanceStateName": instanceStateName,
+		"divf":              func(a, b int64) float64 { return float64(a) / float64(b) },
+		"dict": func(values ...interface{}) map[string]interface{} {
+			d := make(map[string]interface{})
+			for i := 0; i < len(values); i += 2 {
+				key, _ := values[i].(string)
+				d[key] = values[i+1]
+			}
+			return d
+		},
+	}
+
+	tmpl, err := template.New("").Funcs(funcMap).ParseFS(content, "templates/*.html")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse templates: %w", err)
+	}
+
+	return &Handler{
+		db:        database,
+		templates: tmpl,
+		logger:    logger,
+	}, nil
+}
+
+// RegisterRoutes registers all UI routes on the given mux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/ui/", h.handleDashboard)
+	mux.HandleFunc("/ui/nodes", h.handleNodes)
+	mux.HandleFunc("/ui/nodes/", h.handleNodeDetail)
+	mux.HandleFunc("/ui/instances", h.handleInstances)
+
+	// Serve static files from embedded filesystem
+	staticFS, _ := fs.Sub(content, "static")
+	mux.Handle("/ui/static/", http.StripPrefix("/ui/static/", http.FileServer(http.FS(staticFS))))
+}
+
+// Dashboard data
+
+type dashboardData struct {
+	TotalNodes     int
+	ActiveNodes    int
+	CordonedNodes  int
+	DrainingNodes  int
+	UnhealthyNodes int
+	TotalGPUs      int
+	UnhealthyList  []*db.NodeRecord
+}
+
+func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/ui/" && r.URL.Path != "/ui" {
+		http.NotFound(w, r)
+		return
+	}
+
+	nodes, err := h.db.ListNodes(r.Context())
+	if err != nil {
+		h.renderError(w, "Failed to load nodes", err)
+		return
+	}
+
+	data := dashboardData{}
+	for _, node := range nodes {
+		data.TotalNodes++
+		data.TotalGPUs += len(node.GPUs)
+
+		switch node.Status {
+		case pb.NodeStatus_NODE_STATUS_ACTIVE:
+			data.ActiveNodes++
+		case pb.NodeStatus_NODE_STATUS_CORDONED:
+			data.CordonedNodes++
+		case pb.NodeStatus_NODE_STATUS_DRAINING:
+			data.DrainingNodes++
+		case pb.NodeStatus_NODE_STATUS_UNHEALTHY:
+			data.UnhealthyNodes++
+			data.UnhealthyList = append(data.UnhealthyList, node)
+		}
+	}
+
+	h.render(w, "dashboard.html", data)
+}
+
+// Nodes list
+
+type nodesData struct {
+	Nodes        []*db.NodeRecord
+	StatusFilter string
+}
+
+func (h *Handler) handleNodes(w http.ResponseWriter, r *http.Request) {
+	nodes, err := h.db.ListNodes(r.Context())
+	if err != nil {
+		h.renderError(w, "Failed to load nodes", err)
+		return
+	}
+
+	statusFilter := r.URL.Query().Get("status")
+	var filtered []*db.NodeRecord
+
+	if statusFilter != "" {
+		for _, node := range nodes {
+			if statusName(node.Status) == statusFilter {
+				filtered = append(filtered, node)
+			}
+		}
+	} else {
+		filtered = nodes
+	}
+
+	data := nodesData{
+		Nodes:        filtered,
+		StatusFilter: statusFilter,
+	}
+
+	// For HTMX requests, only render the table body
+	if r.Header.Get("HX-Request") == "true" {
+		h.render(w, "nodes_table.html", data)
+		return
+	}
+
+	h.render(w, "nodes.html", data)
+}
+
+// Node detail
+
+type nodeDetailData struct {
+	Node    *db.NodeRecord
+	Message string
+	Error   string
+}
+
+func (h *Handler) handleNodeDetail(w http.ResponseWriter, r *http.Request) {
+	nodeID := strings.TrimPrefix(r.URL.Path, "/ui/nodes/")
+	if nodeID == "" {
+		http.Redirect(w, r, "/ui/nodes", http.StatusFound)
+		return
+	}
+
+	// Handle POST actions
+	if r.Method == http.MethodPost {
+		h.handleNodeAction(w, r, nodeID)
+		return
+	}
+
+	node, err := h.db.GetNode(r.Context(), nodeID)
+	if err != nil {
+		h.renderError(w, "Node not found", err)
+		return
+	}
+
+	data := nodeDetailData{
+		Node:    node,
+		Message: r.URL.Query().Get("message"),
+		Error:   r.URL.Query().Get("error"),
+	}
+
+	h.render(w, "node.html", data)
+}
+
+func (h *Handler) handleNodeAction(w http.ResponseWriter, r *http.Request, nodeID string) {
+	if err := r.ParseForm(); err != nil {
+		http.Redirect(w, r, fmt.Sprintf("/ui/nodes/%s?error=Invalid+form", nodeID), http.StatusFound)
+		return
+	}
+
+	action := r.FormValue("action")
+	reason := r.FormValue("reason")
+
+	var commandType pb.NodeCommandType
+	switch action {
+	case "cordon":
+		commandType = pb.NodeCommandType_NODE_COMMAND_TYPE_CORDON
+	case "uncordon":
+		commandType = pb.NodeCommandType_NODE_COMMAND_TYPE_UNCORDON
+	case "drain":
+		commandType = pb.NodeCommandType_NODE_COMMAND_TYPE_DRAIN
+	default:
+		http.Redirect(w, r, fmt.Sprintf("/ui/nodes/%s?error=Unknown+action", nodeID), http.StatusFound)
+		return
+	}
+
+	// Issue command via DB (simplified - in production would use the RPC)
+	cmd := &db.CommandRecord{
+		CommandID:  fmt.Sprintf("ui-%d", time.Now().UnixNano()),
+		NodeID:     nodeID,
+		Type:       commandType,
+		Parameters: map[string]string{"reason": reason},
+		IssuedAt:   time.Now(),
+		Status:     "pending",
+	}
+
+	// For cordon/uncordon/drain, update node status directly
+	ctx := r.Context()
+	var newStatus pb.NodeStatus
+	switch action {
+	case "cordon":
+		newStatus = pb.NodeStatus_NODE_STATUS_CORDONED
+	case "uncordon":
+		newStatus = pb.NodeStatus_NODE_STATUS_ACTIVE
+	case "drain":
+		newStatus = pb.NodeStatus_NODE_STATUS_DRAINING
+	}
+
+	if err := h.db.UpdateNodeStatus(ctx, nodeID, newStatus); err != nil {
+		h.logger.Error("failed to update node status", slog.String("node_id", nodeID), slog.String("error", err.Error()))
+		http.Redirect(w, r, fmt.Sprintf("/ui/nodes/%s?error=Failed+to+%s+node", nodeID, action), http.StatusFound)
+		return
+	}
+
+	// Record command for audit trail
+	cmd.Status = "completed"
+	if err := h.db.CreateCommand(ctx, cmd); err != nil {
+		h.logger.Warn("failed to record command", slog.String("error", err.Error()))
+	}
+
+	h.logger.Info("node action executed",
+		slog.String("node_id", nodeID),
+		slog.String("action", action),
+	)
+
+	http.Redirect(w, r, fmt.Sprintf("/ui/nodes/%s?message=Node+%sed+successfully", nodeID, action), http.StatusFound)
+}
+
+// Instances list
+
+type instancesData struct {
+	Instances   []*db.InstanceRecord
+	StateFilter string
+}
+
+func (h *Handler) handleInstances(w http.ResponseWriter, r *http.Request) {
+	instances, err := h.db.ListInstances(r.Context())
+	if err != nil {
+		h.renderError(w, "Failed to load instances", err)
+		return
+	}
+
+	stateFilter := r.URL.Query().Get("state")
+	var filtered []*db.InstanceRecord
+
+	if stateFilter != "" {
+		for _, inst := range instances {
+			if instanceStateName(inst.State) == stateFilter {
+				filtered = append(filtered, inst)
+			}
+		}
+	} else {
+		filtered = instances
+	}
+
+	data := instancesData{
+		Instances:   filtered,
+		StateFilter: stateFilter,
+	}
+
+	// For HTMX requests, only render the table body
+	if r.Header.Get("HX-Request") == "true" {
+		h.render(w, "instances_table.html", data)
+		return
+	}
+
+	h.render(w, "instances.html", data)
+}
+
+// Rendering helpers
+
+func (h *Handler) render(w http.ResponseWriter, name string, data interface{}) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := h.templates.ExecuteTemplate(w, name, data); err != nil {
+		h.logger.Error("template render failed", slog.String("template", name), slog.String("error", err.Error()))
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}
+
+func (h *Handler) renderError(w http.ResponseWriter, message string, err error) {
+	h.logger.Error(message, slog.String("error", err.Error()))
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprintf(w, `<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Error</h1><p>%s: %s</p><a href="/ui/">Back to Dashboard</a></body></html>`, message, err.Error())
+}
+
+// Template functions
+
+func statusClass(status pb.NodeStatus) string {
+	switch status {
+	case pb.NodeStatus_NODE_STATUS_ACTIVE:
+		return "status-active"
+	case pb.NodeStatus_NODE_STATUS_CORDONED:
+		return "status-cordoned"
+	case pb.NodeStatus_NODE_STATUS_DRAINING:
+		return "status-draining"
+	case pb.NodeStatus_NODE_STATUS_UNHEALTHY:
+		return "status-unhealthy"
+	case pb.NodeStatus_NODE_STATUS_TERMINATED:
+		return "status-terminated"
+	default:
+		return "status-unknown"
+	}
+}
+
+func healthClass(status pb.HealthStatus) string {
+	switch status {
+	case pb.HealthStatus_HEALTH_STATUS_HEALTHY:
+		return "health-healthy"
+	case pb.HealthStatus_HEALTH_STATUS_DEGRADED:
+		return "health-degraded"
+	case pb.HealthStatus_HEALTH_STATUS_UNHEALTHY:
+		return "health-unhealthy"
+	default:
+		return "health-unknown"
+	}
+}
+
+func instanceStateClass(state pb.InstanceState) string {
+	switch state {
+	case pb.InstanceState_INSTANCE_STATE_RUNNING:
+		return "state-running"
+	case pb.InstanceState_INSTANCE_STATE_PROVISIONING, pb.InstanceState_INSTANCE_STATE_PENDING_REGISTRATION:
+		return "state-pending"
+	case pb.InstanceState_INSTANCE_STATE_TERMINATING, pb.InstanceState_INSTANCE_STATE_TERMINATED:
+		return "state-terminated"
+	case pb.InstanceState_INSTANCE_STATE_FAILED:
+		return "state-failed"
+	default:
+		return "state-unknown"
+	}
+}
+
+func statusName(status pb.NodeStatus) string {
+	switch status {
+	case pb.NodeStatus_NODE_STATUS_ACTIVE:
+		return "Active"
+	case pb.NodeStatus_NODE_STATUS_CORDONED:
+		return "Cordoned"
+	case pb.NodeStatus_NODE_STATUS_DRAINING:
+		return "Draining"
+	case pb.NodeStatus_NODE_STATUS_UNHEALTHY:
+		return "Unhealthy"
+	case pb.NodeStatus_NODE_STATUS_TERMINATED:
+		return "Terminated"
+	default:
+		return "Unknown"
+	}
+}
+
+func healthName(status pb.HealthStatus) string {
+	switch status {
+	case pb.HealthStatus_HEALTH_STATUS_HEALTHY:
+		return "Healthy"
+	case pb.HealthStatus_HEALTH_STATUS_DEGRADED:
+		return "Degraded"
+	case pb.HealthStatus_HEALTH_STATUS_UNHEALTHY:
+		return "Unhealthy"
+	default:
+		return "Unknown"
+	}
+}
+
+func instanceStateName(state pb.InstanceState) string {
+	switch state {
+	case pb.InstanceState_INSTANCE_STATE_PROVISIONING:
+		return "Provisioning"
+	case pb.InstanceState_INSTANCE_STATE_PENDING_REGISTRATION:
+		return "Pending"
+	case pb.InstanceState_INSTANCE_STATE_RUNNING:
+		return "Running"
+	case pb.InstanceState_INSTANCE_STATE_TERMINATING:
+		return "Terminating"
+	case pb.InstanceState_INSTANCE_STATE_TERMINATED:
+		return "Terminated"
+	case pb.InstanceState_INSTANCE_STATE_FAILED:
+		return "Failed"
+	default:
+		return "Unknown"
+	}
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Format("2006-01-02 15:04:05")
+}
+
+func formatDuration(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	d := time.Since(t)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+}

--- a/pkg/ui/handler_test.go
+++ b/pkg/ui/handler_test.go
@@ -1,0 +1,533 @@
+package ui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/NavarchProject/navarch/pkg/controlplane/db"
+	pb "github.com/NavarchProject/navarch/proto"
+)
+
+func TestNewHandler(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+
+	if handler == nil {
+		t.Fatal("NewHandler() returned nil handler")
+	}
+}
+
+func TestDashboard(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	// Add some test nodes
+	ctx := context.Background()
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID:   "node-1",
+		Provider: "gcp",
+		Region:   "us-central1",
+		Status:   pb.NodeStatus_NODE_STATUS_ACTIVE,
+		GPUs:     []*pb.GPUInfo{{Index: 0}, {Index: 1}},
+	})
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID:   "node-2",
+		Provider: "gcp",
+		Region:   "us-central1",
+		Status:   pb.NodeStatus_NODE_STATUS_UNHEALTHY,
+		GPUs:     []*pb.GPUInfo{{Index: 0}},
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/ui/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Fleet Dashboard") {
+		t.Error("response should contain 'Fleet Dashboard'")
+	}
+	if !strings.Contains(body, "2") { // Total nodes
+		t.Error("response should contain node count")
+	}
+	if !strings.Contains(body, "Unhealthy Nodes") {
+		t.Error("response should show unhealthy nodes section")
+	}
+}
+
+func TestNodesList(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID:       "node-1",
+		Provider:     "gcp",
+		Region:       "us-central1",
+		InstanceType: "a3-highgpu-8g",
+		Status:       pb.NodeStatus_NODE_STATUS_ACTIVE,
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/ui/nodes", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "node-1") {
+		t.Error("response should contain node ID")
+	}
+	if !strings.Contains(body, "a3-highgpu-8g") {
+		t.Error("response should contain instance type")
+	}
+}
+
+func TestNodesListWithFilter(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID: "active-node",
+		Status: pb.NodeStatus_NODE_STATUS_ACTIVE,
+	})
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID: "cordoned-node",
+		Status: pb.NodeStatus_NODE_STATUS_CORDONED,
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	// Filter by Active status
+	req := httptest.NewRequest("GET", "/ui/nodes?status=Active", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "active-node") {
+		t.Error("response should contain active node")
+	}
+	if strings.Contains(body, "cordoned-node") {
+		t.Error("response should not contain cordoned node when filtering by Active")
+	}
+}
+
+func TestNodesListHTMXRequest(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID: "node-1",
+		Status: pb.NodeStatus_NODE_STATUS_ACTIVE,
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	// HTMX request should only return table body
+	req := httptest.NewRequest("GET", "/ui/nodes", nil)
+	req.Header.Set("HX-Request", "true")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	// Should contain table content but not full page
+	if !strings.Contains(body, "node-1") {
+		t.Error("HTMX response should contain node data")
+	}
+	if strings.Contains(body, "<!DOCTYPE html>") {
+		t.Error("HTMX response should not contain full HTML document")
+	}
+}
+
+func TestNodeDetail(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID:       "node-1",
+		Provider:     "gcp",
+		Region:       "us-central1",
+		Zone:         "us-central1-a",
+		InstanceType: "a3-highgpu-8g",
+		Status:       pb.NodeStatus_NODE_STATUS_ACTIVE,
+		HealthStatus: pb.HealthStatus_HEALTH_STATUS_HEALTHY,
+		GPUs: []*pb.GPUInfo{
+			{Index: 0, Name: "H100", Uuid: "GPU-123"},
+		},
+		Metadata: &pb.NodeMetadata{
+			Hostname:   "gpu-node-1",
+			InternalIp: "10.0.0.1",
+		},
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/ui/nodes/node-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	checks := []string{"node-1", "gcp", "us-central1", "H100", "gpu-node-1", "Cordon"}
+	for _, check := range checks {
+		if !strings.Contains(body, check) {
+			t.Errorf("response should contain '%s'", check)
+		}
+	}
+}
+
+func TestNodeDetail_NotFound(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/ui/nodes/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500 for not found, got %d", w.Code)
+	}
+}
+
+func TestNodeAction_Cordon(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID: "node-1",
+		Status: pb.NodeStatus_NODE_STATUS_ACTIVE,
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	form := url.Values{}
+	form.Set("action", "cordon")
+	form.Set("reason", "maintenance")
+
+	req := httptest.NewRequest("POST", "/ui/nodes/node-1", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("expected redirect (302), got %d", w.Code)
+	}
+
+	// Verify node status changed
+	node, _ := database.GetNode(ctx, "node-1")
+	if node.Status != pb.NodeStatus_NODE_STATUS_CORDONED {
+		t.Errorf("expected node status CORDONED, got %v", node.Status)
+	}
+}
+
+func TestNodeAction_Uncordon(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID: "node-1",
+		Status: pb.NodeStatus_NODE_STATUS_CORDONED,
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	form := url.Values{}
+	form.Set("action", "uncordon")
+
+	req := httptest.NewRequest("POST", "/ui/nodes/node-1", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("expected redirect (302), got %d", w.Code)
+	}
+
+	node, _ := database.GetNode(ctx, "node-1")
+	if node.Status != pb.NodeStatus_NODE_STATUS_ACTIVE {
+		t.Errorf("expected node status ACTIVE, got %v", node.Status)
+	}
+}
+
+func TestNodeAction_Drain(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.RegisterNode(ctx, &db.NodeRecord{
+		NodeID: "node-1",
+		Status: pb.NodeStatus_NODE_STATUS_ACTIVE,
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	form := url.Values{}
+	form.Set("action", "drain")
+	form.Set("reason", "decommission")
+
+	req := httptest.NewRequest("POST", "/ui/nodes/node-1", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("expected redirect (302), got %d", w.Code)
+	}
+
+	node, _ := database.GetNode(ctx, "node-1")
+	if node.Status != pb.NodeStatus_NODE_STATUS_DRAINING {
+		t.Errorf("expected node status DRAINING, got %v", node.Status)
+	}
+}
+
+func TestInstancesList(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.CreateInstance(ctx, &db.InstanceRecord{
+		InstanceID:   "instance-1",
+		Provider:     "gcp",
+		Region:       "us-central1",
+		InstanceType: "a3-highgpu-8g",
+		State:        pb.InstanceState_INSTANCE_STATE_RUNNING,
+		PoolName:     "default",
+		NodeID:       "node-1",
+		CreatedAt:    time.Now().Add(-1 * time.Hour),
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/ui/instances", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "instance-1") {
+		t.Error("response should contain instance ID")
+	}
+	if !strings.Contains(body, "Running") {
+		t.Error("response should contain instance state")
+	}
+}
+
+func TestInstancesListWithFilter(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	ctx := context.Background()
+	database.CreateInstance(ctx, &db.InstanceRecord{
+		InstanceID: "running-1",
+		State:      pb.InstanceState_INSTANCE_STATE_RUNNING,
+	})
+	database.CreateInstance(ctx, &db.InstanceRecord{
+		InstanceID: "failed-1",
+		State:      pb.InstanceState_INSTANCE_STATE_FAILED,
+	})
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/ui/instances?state=Running", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "running-1") {
+		t.Error("response should contain running instance")
+	}
+	if strings.Contains(body, "failed-1") {
+		t.Error("response should not contain failed instance when filtering by Running")
+	}
+}
+
+func TestStaticFiles(t *testing.T) {
+	database := db.NewInMemDB()
+	defer database.Close()
+
+	handler, err := NewHandler(database, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	req := httptest.NewRequest("GET", "/ui/static/style.css", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200 for static file, got %d", w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "text/css") {
+		t.Errorf("expected CSS content type, got %s", contentType)
+	}
+}
+
+func TestTemplateFunctions(t *testing.T) {
+	tests := []struct {
+		name     string
+		fn       func() string
+		expected string
+	}{
+		{"statusName Active", func() string { return statusName(pb.NodeStatus_NODE_STATUS_ACTIVE) }, "Active"},
+		{"statusName Cordoned", func() string { return statusName(pb.NodeStatus_NODE_STATUS_CORDONED) }, "Cordoned"},
+		{"statusName Unknown", func() string { return statusName(pb.NodeStatus_NODE_STATUS_UNKNOWN) }, "Unknown"},
+		{"healthName Healthy", func() string { return healthName(pb.HealthStatus_HEALTH_STATUS_HEALTHY) }, "Healthy"},
+		{"healthName Degraded", func() string { return healthName(pb.HealthStatus_HEALTH_STATUS_DEGRADED) }, "Degraded"},
+		{"instanceStateName Running", func() string { return instanceStateName(pb.InstanceState_INSTANCE_STATE_RUNNING) }, "Running"},
+		{"instanceStateName Failed", func() string { return instanceStateName(pb.InstanceState_INSTANCE_STATE_FAILED) }, "Failed"},
+		{"statusClass Active", func() string { return statusClass(pb.NodeStatus_NODE_STATUS_ACTIVE) }, "status-active"},
+		{"healthClass Healthy", func() string { return healthClass(pb.HealthStatus_HEALTH_STATUS_HEALTHY) }, "health-healthy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.fn()
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    time.Time
+		contains string
+	}{
+		{"zero time", time.Time{}, "-"},
+		{"seconds ago", time.Now().Add(-30 * time.Second), "s ago"},
+		{"minutes ago", time.Now().Add(-5 * time.Minute), "m ago"},
+		{"hours ago", time.Now().Add(-2 * time.Hour), "h ago"},
+		{"days ago", time.Now().Add(-3 * 24 * time.Hour), "d ago"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatDuration(tt.input)
+			if !strings.Contains(result, tt.contains) {
+				t.Errorf("expected result to contain %q, got %q", tt.contains, result)
+			}
+		})
+	}
+}
+
+func TestFormatTime(t *testing.T) {
+	t.Run("zero time", func(t *testing.T) {
+		result := formatTime(time.Time{})
+		if result != "-" {
+			t.Errorf("expected '-', got %q", result)
+		}
+	})
+
+	t.Run("valid time", func(t *testing.T) {
+		ts := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+		result := formatTime(ts)
+		if result != "2024-01-15 10:30:00" {
+			t.Errorf("expected '2024-01-15 10:30:00', got %q", result)
+		}
+	})
+}

--- a/pkg/ui/static/style.css
+++ b/pkg/ui/static/style.css
@@ -1,0 +1,532 @@
+:root {
+    --ds-background-100: #0a0a0a;
+    --ds-background-200: #000;
+    --ds-gray-100: #1a1a1a;
+    --ds-gray-200: #1f1f1f;
+    --ds-gray-400: #292929;
+    --ds-gray-600: #454545;
+    --ds-gray-700: #878787;
+    --ds-gray-900: #a1a1a1;
+    --ds-gray-1000: #ededed;
+    --ds-blue-700: #52a8ff;
+    --ds-blue-900: #0070f3;
+    --ds-green-700: #3ecf8e;
+    --ds-green-900: #0cce6b;
+    --ds-amber-700: #ffb224;
+    --ds-amber-900: #f5a623;
+    --ds-red-700: #ff6369;
+    --ds-red-900: #e5484d;
+    --sidebar-width: 220px;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--ds-background-200);
+    color: var(--ds-gray-1000);
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* Layout */
+.layout {
+    display: flex;
+    min-height: 100vh;
+}
+
+/* Sidebar */
+.sidebar {
+    width: var(--sidebar-width);
+    background: var(--ds-background-200);
+    border-right: 1px solid var(--ds-gray-200);
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+}
+
+.sidebar-header {
+    height: 48px;
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--ds-gray-200);
+}
+
+.logo {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 500;
+    font-size: 14px;
+    color: var(--ds-gray-1000);
+}
+
+.logo svg {
+    color: var(--ds-gray-1000);
+}
+
+.sidebar-nav {
+    flex: 1;
+    padding: 8px;
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    color: var(--ds-gray-900);
+    text-decoration: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 400;
+    transition: background 0.1s, color 0.1s;
+}
+
+.nav-item:hover {
+    background: var(--ds-gray-100);
+    color: var(--ds-gray-1000);
+}
+
+.nav-item svg {
+    color: var(--ds-gray-700);
+    transition: color 0.1s;
+}
+
+.nav-item:hover svg {
+    color: var(--ds-gray-1000);
+}
+
+.sidebar-footer {
+    padding: 12px;
+    border-top: 1px solid var(--ds-gray-200);
+}
+
+.version {
+    font-size: 12px;
+    color: var(--ds-gray-700);
+}
+
+/* Main */
+main {
+    flex: 1;
+    margin-left: var(--sidebar-width);
+    display: flex;
+    flex-direction: column;
+}
+
+.topbar {
+    height: 48px;
+    border-bottom: 1px solid var(--ds-gray-200);
+    display: flex;
+    align-items: center;
+    padding: 0 24px;
+    background: var(--ds-background-200);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.breadcrumb {
+    font-size: 14px;
+    color: var(--ds-gray-700);
+}
+
+.content {
+    padding: 24px;
+}
+
+/* Typography */
+h1 {
+    font-size: 24px;
+    font-weight: 500;
+    margin-bottom: 24px;
+    letter-spacing: -0.02em;
+    color: var(--ds-gray-1000);
+}
+
+h2 {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--ds-gray-700);
+    margin: 24px 0 12px;
+}
+
+h3 {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--ds-gray-700);
+    margin: 16px 0 8px;
+}
+
+/* Stats */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 1px;
+    background: var(--ds-gray-200);
+    border: 1px solid var(--ds-gray-200);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 32px;
+}
+
+.stat-card {
+    background: var(--ds-background-100);
+    padding: 20px;
+}
+
+.stat-value {
+    font-size: 28px;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+    margin-bottom: 4px;
+}
+
+.stat-label {
+    font-size: 13px;
+    color: var(--ds-gray-700);
+}
+
+.stat-active .stat-value { color: var(--ds-green-700); }
+.stat-cordoned .stat-value { color: var(--ds-amber-700); }
+.stat-draining .stat-value { color: var(--ds-amber-700); }
+.stat-unhealthy .stat-value { color: var(--ds-red-700); }
+
+/* Tables */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid var(--ds-gray-200);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+th {
+    background: var(--ds-background-100);
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--ds-gray-700);
+    border-bottom: 1px solid var(--ds-gray-200);
+}
+
+td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--ds-gray-200);
+    font-size: 14px;
+    color: var(--ds-gray-1000);
+}
+
+tbody tr {
+    background: var(--ds-background-200);
+    transition: background 0.1s;
+}
+
+tbody tr:hover {
+    background: var(--ds-gray-100);
+}
+
+tbody tr:last-child td {
+    border-bottom: none;
+}
+
+td a {
+    color: var(--ds-gray-1000);
+    text-decoration: none;
+}
+
+td a:hover {
+    text-decoration: underline;
+}
+
+td.empty {
+    text-align: center;
+    color: var(--ds-gray-700);
+    padding: 40px 16px;
+}
+
+.mono {
+    font-family: 'Geist Mono', 'SF Mono', monospace;
+    font-size: 13px;
+}
+
+/* Badges */
+.badge {
+    display: inline-flex;
+    align-items: center;
+    height: 22px;
+    padding: 0 8px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.status-active, .health-healthy, .state-running {
+    background: rgba(60, 207, 142, 0.1);
+    color: var(--ds-green-700);
+}
+
+.status-cordoned, .health-degraded, .state-pending {
+    background: rgba(255, 178, 36, 0.1);
+    color: var(--ds-amber-700);
+}
+
+.status-draining {
+    background: rgba(255, 178, 36, 0.1);
+    color: var(--ds-amber-700);
+}
+
+.status-unhealthy, .health-unhealthy, .state-failed {
+    background: rgba(255, 99, 105, 0.1);
+    color: var(--ds-red-700);
+}
+
+.status-terminated, .state-terminated,
+.status-unknown, .health-unknown, .state-unknown {
+    background: var(--ds-gray-200);
+    color: var(--ds-gray-700);
+}
+
+/* Filters */
+.filters {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.filters label {
+    font-size: 13px;
+    color: var(--ds-gray-700);
+}
+
+.filters select {
+    background: var(--ds-background-100);
+    color: var(--ds-gray-1000);
+    border: 1px solid var(--ds-gray-400);
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+}
+
+.filters select:hover {
+    border-color: var(--ds-gray-600);
+}
+
+.filters select:focus {
+    outline: none;
+    border-color: var(--ds-gray-1000);
+}
+
+.node-count {
+    margin-left: auto;
+    font-size: 13px;
+    color: var(--ds-gray-700);
+}
+
+/* Node detail */
+.node-info {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.info-section {
+    background: var(--ds-background-100);
+    border: 1px solid var(--ds-gray-200);
+    border-radius: 8px;
+    padding: 16px;
+}
+
+.info-section h2 {
+    margin: 0 0 12px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--ds-gray-200);
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--ds-gray-1000);
+}
+
+dl {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    gap: 6px;
+    font-size: 13px;
+}
+
+dt {
+    color: var(--ds-gray-700);
+}
+
+dd {
+    color: var(--ds-gray-1000);
+}
+
+/* Actions */
+.actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 24px;
+}
+
+.action-form {
+    display: flex;
+    gap: 8px;
+}
+
+.action-form input[type="text"] {
+    background: var(--ds-background-100);
+    color: var(--ds-gray-1000);
+    border: 1px solid var(--ds-gray-400);
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 13px;
+    font-family: inherit;
+    width: 160px;
+}
+
+.action-form input:focus {
+    outline: none;
+    border-color: var(--ds-gray-1000);
+}
+
+.action-form input::placeholder {
+    color: var(--ds-gray-700);
+}
+
+/* Buttons */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 32px;
+    padding: 0 12px;
+    border: 1px solid var(--ds-gray-400);
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    text-decoration: none;
+    background: var(--ds-background-100);
+    color: var(--ds-gray-1000);
+    transition: all 0.1s;
+}
+
+.btn:hover {
+    background: var(--ds-gray-100);
+    border-color: var(--ds-gray-600);
+}
+
+.btn-success {
+    background: var(--ds-green-900);
+    color: #000;
+    border: none;
+}
+
+.btn-success:hover {
+    background: var(--ds-green-700);
+}
+
+.btn-warning {
+    background: var(--ds-amber-900);
+    color: #000;
+    border: none;
+}
+
+.btn-warning:hover {
+    background: var(--ds-amber-700);
+}
+
+.btn-danger {
+    background: var(--ds-red-900);
+    color: #fff;
+    border: none;
+}
+
+.btn-danger:hover {
+    background: var(--ds-red-700);
+}
+
+/* Alerts */
+.alert {
+    padding: 10px 12px;
+    border-radius: 6px;
+    margin-bottom: 16px;
+    font-size: 13px;
+}
+
+.alert-success {
+    background: rgba(60, 207, 142, 0.1);
+    color: var(--ds-green-700);
+}
+
+.alert-error {
+    background: rgba(255, 99, 105, 0.1);
+    color: var(--ds-red-700);
+}
+
+/* Quick links */
+.quick-links {
+    margin-top: 24px;
+    padding-top: 24px;
+    border-top: 1px solid var(--ds-gray-200);
+}
+
+.quick-links h2 {
+    margin-bottom: 12px;
+}
+
+.quick-links .btn {
+    margin-right: 8px;
+    margin-bottom: 8px;
+}
+
+/* Utilities */
+.muted {
+    color: var(--ds-gray-700);
+}
+
+.content > p:last-child a {
+    color: var(--ds-gray-900);
+    text-decoration: none;
+    font-size: 13px;
+}
+
+.content > p:last-child a:hover {
+    color: var(--ds-gray-1000);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--ds-gray-400);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--ds-gray-600);
+}

--- a/pkg/ui/templates/base.html
+++ b/pkg/ui/templates/base.html
@@ -1,0 +1,63 @@
+{{define "header"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.Title}} - Navarch</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1.2.0/dist/fonts/geist-sans/style.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1.2.0/dist/fonts/geist-mono/style.min.css">
+    <link rel="stylesheet" href="/ui/static/style.css">
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body>
+    <div class="layout">
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <div class="logo">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 2L2 19h20L12 2zm0 4l7 11H5l7-11z"/>
+                    </svg>
+                    <span>Navarch</span>
+                </div>
+            </div>
+            <nav class="sidebar-nav">
+                <a href="/ui/" class="nav-item">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
+                        <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
+                    </svg>
+                    Dashboard
+                </a>
+                <a href="/ui/nodes" class="nav-item">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect x="4" y="4" width="16" height="16" rx="2"/>
+                        <rect x="9" y="9" width="6" height="6"/>
+                    </svg>
+                    Nodes
+                </a>
+                <a href="/ui/instances" class="nav-item">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="12" cy="12" r="3"/><path d="M12 2v4m0 12v4M2 12h4m12 0h4"/>
+                    </svg>
+                    Instances
+                </a>
+            </nav>
+            <div class="sidebar-footer">
+                <div class="version">v0.1.0</div>
+            </div>
+        </aside>
+        <main>
+            <header class="topbar">
+                <div class="breadcrumb">{{.Title}}</div>
+            </header>
+            <div class="content">
+{{end}}
+
+{{define "footer"}}
+            </div>
+        </main>
+    </div>
+</body>
+</html>
+{{end}}

--- a/pkg/ui/templates/dashboard.html
+++ b/pkg/ui/templates/dashboard.html
@@ -1,0 +1,67 @@
+{{define "dashboard.html"}}
+{{template "header" dict "Title" "Dashboard"}}
+
+<h1>Fleet Dashboard</h1>
+
+<div class="stats-grid">
+    <div class="stat-card">
+        <div class="stat-value">{{.TotalNodes}}</div>
+        <div class="stat-label">Total Nodes</div>
+    </div>
+    <div class="stat-card stat-active">
+        <div class="stat-value">{{.ActiveNodes}}</div>
+        <div class="stat-label">Active</div>
+    </div>
+    <div class="stat-card stat-cordoned">
+        <div class="stat-value">{{.CordonedNodes}}</div>
+        <div class="stat-label">Cordoned</div>
+    </div>
+    <div class="stat-card stat-draining">
+        <div class="stat-value">{{.DrainingNodes}}</div>
+        <div class="stat-label">Draining</div>
+    </div>
+    <div class="stat-card stat-unhealthy">
+        <div class="stat-value">{{.UnhealthyNodes}}</div>
+        <div class="stat-label">Unhealthy</div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-value">{{.TotalGPUs}}</div>
+        <div class="stat-label">Total GPUs</div>
+    </div>
+</div>
+
+{{if .UnhealthyList}}
+<h2>Unhealthy Nodes</h2>
+<table>
+    <thead>
+        <tr>
+            <th>Node ID</th>
+            <th>Provider</th>
+            <th>Region</th>
+            <th>Instance Type</th>
+            <th>Last Heartbeat</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{range .UnhealthyList}}
+        <tr>
+            <td><a href="/ui/nodes/{{.NodeID}}">{{.NodeID}}</a></td>
+            <td>{{.Provider}}</td>
+            <td>{{.Region}}</td>
+            <td>{{.InstanceType}}</td>
+            <td>{{formatDuration .LastHeartbeat}}</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{end}}
+
+<div class="quick-links">
+    <h2>Quick Links</h2>
+    <a href="/ui/nodes" class="btn">View All Nodes</a>
+    <a href="/ui/nodes?status=Unhealthy" class="btn btn-warning">Unhealthy Nodes</a>
+    <a href="/ui/instances" class="btn">View Instances</a>
+</div>
+
+{{template "footer"}}
+{{end}}

--- a/pkg/ui/templates/instances.html
+++ b/pkg/ui/templates/instances.html
@@ -1,0 +1,32 @@
+{{define "instances.html"}}
+{{template "header" dict "Title" "Instances"}}
+
+<h1>Cloud Instances</h1>
+
+<div class="filters">
+    <label for="state-filter">State:</label>
+    <select id="state-filter"
+            hx-get="/ui/instances"
+            hx-target="#instances-table"
+            hx-trigger="change"
+            name="state">
+        <option value="" {{if eq .StateFilter ""}}selected{{end}}>All</option>
+        <option value="Provisioning" {{if eq .StateFilter "Provisioning"}}selected{{end}}>Provisioning</option>
+        <option value="Pending" {{if eq .StateFilter "Pending"}}selected{{end}}>Pending</option>
+        <option value="Running" {{if eq .StateFilter "Running"}}selected{{end}}>Running</option>
+        <option value="Terminating" {{if eq .StateFilter "Terminating"}}selected{{end}}>Terminating</option>
+        <option value="Terminated" {{if eq .StateFilter "Terminated"}}selected{{end}}>Terminated</option>
+        <option value="Failed" {{if eq .StateFilter "Failed"}}selected{{end}}>Failed</option>
+    </select>
+    <span class="node-count">{{len .Instances}} instances</span>
+</div>
+
+<div id="instances-table"
+     hx-get="/ui/instances{{if .StateFilter}}?state={{.StateFilter}}{{end}}"
+     hx-trigger="every 5s"
+     hx-swap="innerHTML">
+    {{template "instances_table.html" .}}
+</div>
+
+{{template "footer"}}
+{{end}}

--- a/pkg/ui/templates/instances_table.html
+++ b/pkg/ui/templates/instances_table.html
@@ -1,0 +1,36 @@
+{{define "instances_table.html"}}
+<table>
+    <thead>
+        <tr>
+            <th>Instance ID</th>
+            <th>Provider</th>
+            <th>Region</th>
+            <th>Pool</th>
+            <th>Instance Type</th>
+            <th>State</th>
+            <th>Node</th>
+            <th>Created</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{if .Instances}}
+        {{range .Instances}}
+        <tr>
+            <td class="mono">{{.InstanceID}}</td>
+            <td>{{.Provider}}</td>
+            <td>{{.Region}}</td>
+            <td>{{if .PoolName}}{{.PoolName}}{{else}}-{{end}}</td>
+            <td>{{.InstanceType}}</td>
+            <td><span class="badge {{instanceStateClass .State}}">{{instanceStateName .State}}</span></td>
+            <td>{{if .NodeID}}<a href="/ui/nodes/{{.NodeID}}">{{.NodeID}}</a>{{else}}-{{end}}</td>
+            <td>{{formatDuration .CreatedAt}}</td>
+        </tr>
+        {{end}}
+        {{else}}
+        <tr>
+            <td colspan="8" class="empty">No instances found</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{end}}

--- a/pkg/ui/templates/node.html
+++ b/pkg/ui/templates/node.html
@@ -1,0 +1,127 @@
+{{define "node.html"}}
+{{template "header" dict "Title" .Node.NodeID}}
+
+<h1>Node: {{.Node.NodeID}}</h1>
+
+{{if .Message}}
+<div class="alert alert-success">{{.Message}}</div>
+{{end}}
+{{if .Error}}
+<div class="alert alert-error">{{.Error}}</div>
+{{end}}
+
+<div class="node-info">
+    <div class="info-section">
+        <h2>Status</h2>
+        <dl>
+            <dt>Status</dt>
+            <dd><span class="badge {{statusClass .Node.Status}}">{{statusName .Node.Status}}</span></dd>
+            <dt>Health</dt>
+            <dd><span class="badge {{healthClass .Node.HealthStatus}}">{{healthName .Node.HealthStatus}}</span></dd>
+            <dt>Last Heartbeat</dt>
+            <dd>{{formatTime .Node.LastHeartbeat}} ({{formatDuration .Node.LastHeartbeat}})</dd>
+            <dt>Registered</dt>
+            <dd>{{formatTime .Node.RegisteredAt}}</dd>
+        </dl>
+    </div>
+
+    <div class="info-section">
+        <h2>Infrastructure</h2>
+        <dl>
+            <dt>Provider</dt>
+            <dd>{{.Node.Provider}}</dd>
+            <dt>Region</dt>
+            <dd>{{.Node.Region}}</dd>
+            <dt>Zone</dt>
+            <dd>{{.Node.Zone}}</dd>
+            <dt>Instance Type</dt>
+            <dd>{{.Node.InstanceType}}</dd>
+        </dl>
+    </div>
+
+    {{if .Node.Metadata}}
+    <div class="info-section">
+        <h2>Metadata</h2>
+        <dl>
+            <dt>Hostname</dt>
+            <dd>{{.Node.Metadata.Hostname}}</dd>
+            <dt>Internal IP</dt>
+            <dd>{{.Node.Metadata.InternalIp}}</dd>
+            {{if .Node.Metadata.ExternalIp}}
+            <dt>External IP</dt>
+            <dd>{{.Node.Metadata.ExternalIp}}</dd>
+            {{end}}
+            <dt>Kernel</dt>
+            <dd>{{.Node.Metadata.KernelVersion}}</dd>
+        </dl>
+        {{if .Node.Metadata.Labels}}
+        <h3>Labels</h3>
+        <dl>
+            {{range $k, $v := .Node.Metadata.Labels}}
+            <dt>{{$k}}</dt>
+            <dd>{{$v}}</dd>
+            {{end}}
+        </dl>
+        {{end}}
+    </div>
+    {{end}}
+</div>
+
+{{if .Node.GPUs}}
+<h2>GPUs ({{len .Node.GPUs}})</h2>
+<table>
+    <thead>
+        <tr>
+            <th>Index</th>
+            <th>Name</th>
+            <th>UUID</th>
+            <th>Memory</th>
+            <th>Driver</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{range .Node.GPUs}}
+        <tr>
+            <td>{{.Index}}</td>
+            <td>{{.Name}}</td>
+            <td class="mono">{{.Uuid}}</td>
+            <td>{{printf "%.0f" (divf .MemoryTotal 1073741824)}} GB</td>
+            <td>{{.DriverVersion}}</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{end}}
+
+<h2>Actions</h2>
+<div class="actions">
+    {{if eq (statusName .Node.Status) "Active"}}
+    <form method="POST" class="action-form">
+        <input type="hidden" name="action" value="cordon">
+        <input type="text" name="reason" placeholder="Reason (optional)">
+        <button type="submit" class="btn btn-warning">Cordon</button>
+    </form>
+    <form method="POST" class="action-form">
+        <input type="hidden" name="action" value="drain">
+        <input type="text" name="reason" placeholder="Reason (optional)">
+        <button type="submit" class="btn btn-danger">Drain</button>
+    </form>
+    {{else if eq (statusName .Node.Status) "Cordoned"}}
+    <form method="POST" class="action-form">
+        <input type="hidden" name="action" value="uncordon">
+        <button type="submit" class="btn btn-success">Uncordon</button>
+    </form>
+    <form method="POST" class="action-form">
+        <input type="hidden" name="action" value="drain">
+        <input type="text" name="reason" placeholder="Reason (optional)">
+        <button type="submit" class="btn btn-danger">Drain</button>
+    </form>
+    {{else}}
+    <p class="muted">No actions available for nodes in {{statusName .Node.Status}} status.</p>
+    {{end}}
+</div>
+
+<p><a href="/ui/nodes">&larr; Back to Nodes</a></p>
+
+{{template "footer"}}
+{{end}}

--- a/pkg/ui/templates/nodes.html
+++ b/pkg/ui/templates/nodes.html
@@ -1,0 +1,30 @@
+{{define "nodes.html"}}
+{{template "header" dict "Title" "Nodes"}}
+
+<h1>Nodes</h1>
+
+<div class="filters">
+    <label for="status-filter">Status:</label>
+    <select id="status-filter"
+            hx-get="/ui/nodes"
+            hx-target="#nodes-table"
+            hx-trigger="change"
+            name="status">
+        <option value="" {{if eq .StatusFilter ""}}selected{{end}}>All</option>
+        <option value="Active" {{if eq .StatusFilter "Active"}}selected{{end}}>Active</option>
+        <option value="Cordoned" {{if eq .StatusFilter "Cordoned"}}selected{{end}}>Cordoned</option>
+        <option value="Draining" {{if eq .StatusFilter "Draining"}}selected{{end}}>Draining</option>
+        <option value="Unhealthy" {{if eq .StatusFilter "Unhealthy"}}selected{{end}}>Unhealthy</option>
+    </select>
+    <span class="node-count">{{len .Nodes}} nodes</span>
+</div>
+
+<div id="nodes-table"
+     hx-get="/ui/nodes{{if .StatusFilter}}?status={{.StatusFilter}}{{end}}"
+     hx-trigger="every 5s"
+     hx-swap="innerHTML">
+    {{template "nodes_table.html" .}}
+</div>
+
+{{template "footer"}}
+{{end}}

--- a/pkg/ui/templates/nodes_table.html
+++ b/pkg/ui/templates/nodes_table.html
@@ -1,0 +1,36 @@
+{{define "nodes_table.html"}}
+<table>
+    <thead>
+        <tr>
+            <th>Node ID</th>
+            <th>Provider</th>
+            <th>Region</th>
+            <th>Instance Type</th>
+            <th>GPUs</th>
+            <th>Status</th>
+            <th>Health</th>
+            <th>Last Heartbeat</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{if .Nodes}}
+        {{range .Nodes}}
+        <tr>
+            <td><a href="/ui/nodes/{{.NodeID}}">{{.NodeID}}</a></td>
+            <td>{{.Provider}}</td>
+            <td>{{.Region}}</td>
+            <td>{{.InstanceType}}</td>
+            <td>{{len .GPUs}}</td>
+            <td><span class="badge {{statusClass .Status}}">{{statusName .Status}}</span></td>
+            <td><span class="badge {{healthClass .HealthStatus}}">{{healthName .HealthStatus}}</span></td>
+            <td>{{formatDuration .LastHeartbeat}}</td>
+        </tr>
+        {{end}}
+        {{else}}
+        <tr>
+            <td colspan="8" class="empty">No nodes found</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{end}}


### PR DESCRIPTION
## Summary

- Add `pkg/ui` with Go templates + HTMX for real-time fleet monitoring dashboard
- Modern dark theme styling using Vercel design system (Geist font, dark colors)
- Dashboard with fleet summary and node counts by status
- Nodes list with filtering by status and auto-refresh (5s HTMX polling)
- Node detail page with cordon/uncordon/drain action buttons
- Instances page for cloud instance lifecycle tracking
- Add `--keep-alive` flag to simulator for demo/interactive mode
- Fix simulator fleet generator to use correct instance types per cloud provider
- Add auth middleware prefix exclusion for `/ui/*` paths (assumes private network)

## Test plan

- [x] Run `go test ./pkg/ui/...` - 16 tests pass
- [x] Run `go test ./pkg/auth/...` - middleware tests pass
- [ ] Start simulator: `./simulator run --keep-alive scenarios/stress/demo.yaml`
- [ ] Open http://localhost:8080/ui/ and verify dashboard loads
- [ ] Verify nodes list auto-refreshes every 5s
- [ ] Click a node to see details, test cordon/drain buttons
- [ ] Verify instance types are correct per provider (AWS: p5.48xlarge, GCP: a3-highgpu-8g)

🤖 Generated with [Claude Code](https://claude.ai/code)