### PR TITLE
Add availability failover with exponential backoff

### DIFF
--- a/pkg/pool/failuretracker.go
+++ b/pkg/pool/failuretracker.go
@@ -1,0 +1,188 @@
+package pool
+
+import (
+	"sync"
+	"time"
+)
+
+// FailureTracker tracks provisioning failures per provider/zone with exponential backoff.
+// Providers that fail repeatedly are temporarily excluded from selection.
+type FailureTracker struct {
+	mu       sync.RWMutex
+	failures map[string]*failureRecord
+
+	// Configuration
+	baseBackoff    time.Duration // Initial backoff after first failure
+	maxBackoff     time.Duration // Maximum backoff duration
+	backoffFactor  float64       // Multiplier for each consecutive failure
+	resetAfter     time.Duration // Reset failure count after this duration of success
+}
+
+type failureRecord struct {
+	count        int       // Consecutive failure count
+	lastFailure  time.Time // When the last failure occurred
+	excludeUntil time.Time // Provider excluded until this time
+}
+
+// FailureTrackerOption configures the FailureTracker.
+type FailureTrackerOption func(*FailureTracker)
+
+// WithBaseBackoff sets the initial backoff duration (default: 30s).
+func WithBaseBackoff(d time.Duration) FailureTrackerOption {
+	return func(ft *FailureTracker) {
+		ft.baseBackoff = d
+	}
+}
+
+// WithMaxBackoff sets the maximum backoff duration (default: 10m).
+func WithMaxBackoff(d time.Duration) FailureTrackerOption {
+	return func(ft *FailureTracker) {
+		ft.maxBackoff = d
+	}
+}
+
+// WithBackoffFactor sets the backoff multiplier (default: 2.0).
+func WithBackoffFactor(f float64) FailureTrackerOption {
+	return func(ft *FailureTracker) {
+		ft.backoffFactor = f
+	}
+}
+
+// WithResetAfter sets how long success must be sustained to reset failures (default: 5m).
+func WithResetAfter(d time.Duration) FailureTrackerOption {
+	return func(ft *FailureTracker) {
+		ft.resetAfter = d
+	}
+}
+
+// NewFailureTracker creates a new failure tracker with the given options.
+func NewFailureTracker(opts ...FailureTrackerOption) *FailureTracker {
+	ft := &FailureTracker{
+		failures:      make(map[string]*failureRecord),
+		baseBackoff:   30 * time.Second,
+		maxBackoff:    10 * time.Minute,
+		backoffFactor: 2.0,
+		resetAfter:    5 * time.Minute,
+	}
+	for _, opt := range opts {
+		opt(ft)
+	}
+	return ft
+}
+
+// RecordFailure records a provisioning failure for the given key (provider or provider:zone).
+// Returns the duration until the provider should be retried.
+func (ft *FailureTracker) RecordFailure(key string, now time.Time) time.Duration {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	record, ok := ft.failures[key]
+	if !ok {
+		record = &failureRecord{}
+		ft.failures[key] = record
+	}
+
+	record.count++
+	record.lastFailure = now
+
+	// Calculate backoff with exponential growth
+	backoff := ft.baseBackoff
+	for i := 1; i < record.count; i++ {
+		backoff = time.Duration(float64(backoff) * ft.backoffFactor)
+		if backoff > ft.maxBackoff {
+			backoff = ft.maxBackoff
+			break
+		}
+	}
+
+	record.excludeUntil = now.Add(backoff)
+	return backoff
+}
+
+// RecordSuccess records a successful provisioning for the given key.
+// If enough time has passed since the last failure, resets the failure count.
+func (ft *FailureTracker) RecordSuccess(key string, now time.Time) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	record, ok := ft.failures[key]
+	if !ok {
+		return
+	}
+
+	// Reset if enough time has passed since last failure
+	if now.Sub(record.lastFailure) >= ft.resetAfter {
+		delete(ft.failures, key)
+	}
+}
+
+// IsExcluded returns true if the key is currently in a backoff period.
+func (ft *FailureTracker) IsExcluded(key string, now time.Time) bool {
+	ft.mu.RLock()
+	defer ft.mu.RUnlock()
+
+	record, ok := ft.failures[key]
+	if !ok {
+		return false
+	}
+
+	return now.Before(record.excludeUntil)
+}
+
+// GetFailureCount returns the consecutive failure count for a key.
+func (ft *FailureTracker) GetFailureCount(key string) int {
+	ft.mu.RLock()
+	defer ft.mu.RUnlock()
+
+	if record, ok := ft.failures[key]; ok {
+		return record.count
+	}
+	return 0
+}
+
+// GetExcludeUntil returns when a key's exclusion period ends.
+// Returns zero time if the key is not excluded.
+func (ft *FailureTracker) GetExcludeUntil(key string) time.Time {
+	ft.mu.RLock()
+	defer ft.mu.RUnlock()
+
+	if record, ok := ft.failures[key]; ok {
+		return record.excludeUntil
+	}
+	return time.Time{}
+}
+
+// Reset clears all failure records.
+func (ft *FailureTracker) Reset() {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	ft.failures = make(map[string]*failureRecord)
+}
+
+// Stats returns current failure statistics for monitoring.
+type FailureStats struct {
+	Key          string
+	FailureCount int
+	LastFailure  time.Time
+	ExcludedFor  time.Duration // Remaining exclusion time (0 if not excluded)
+}
+
+// GetStats returns failure statistics for all tracked keys.
+func (ft *FailureTracker) GetStats(now time.Time) []FailureStats {
+	ft.mu.RLock()
+	defer ft.mu.RUnlock()
+
+	stats := make([]FailureStats, 0, len(ft.failures))
+	for key, record := range ft.failures {
+		s := FailureStats{
+			Key:          key,
+			FailureCount: record.count,
+			LastFailure:  record.lastFailure,
+		}
+		if now.Before(record.excludeUntil) {
+			s.ExcludedFor = record.excludeUntil.Sub(now)
+		}
+		stats = append(stats, s)
+	}
+	return stats
+}

--- a/pkg/pool/failuretracker_test.go
+++ b/pkg/pool/failuretracker_test.go
@@ -1,0 +1,184 @@
+package pool
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFailureTracker_BasicBackoff(t *testing.T) {
+	ft := NewFailureTracker(
+		WithBaseBackoff(1*time.Second),
+		WithBackoffFactor(2.0),
+		WithMaxBackoff(10*time.Second),
+	)
+
+	now := time.Now()
+
+	// First failure: 1s backoff
+	backoff := ft.RecordFailure("provider-a", now)
+	if backoff != 1*time.Second {
+		t.Errorf("first backoff = %v, want 1s", backoff)
+	}
+	if !ft.IsExcluded("provider-a", now) {
+		t.Error("provider-a should be excluded after failure")
+	}
+
+	// Second failure: 2s backoff
+	now = now.Add(2 * time.Second)
+	backoff = ft.RecordFailure("provider-a", now)
+	if backoff != 2*time.Second {
+		t.Errorf("second backoff = %v, want 2s", backoff)
+	}
+
+	// Third failure: 4s backoff
+	now = now.Add(3 * time.Second)
+	backoff = ft.RecordFailure("provider-a", now)
+	if backoff != 4*time.Second {
+		t.Errorf("third backoff = %v, want 4s", backoff)
+	}
+
+	// Fourth failure: 8s backoff
+	now = now.Add(5 * time.Second)
+	backoff = ft.RecordFailure("provider-a", now)
+	if backoff != 8*time.Second {
+		t.Errorf("fourth backoff = %v, want 8s", backoff)
+	}
+
+	// Fifth failure: capped at 10s
+	now = now.Add(10 * time.Second)
+	backoff = ft.RecordFailure("provider-a", now)
+	if backoff != 10*time.Second {
+		t.Errorf("fifth backoff = %v, want 10s (capped)", backoff)
+	}
+}
+
+func TestFailureTracker_ExclusionExpiry(t *testing.T) {
+	ft := NewFailureTracker(
+		WithBaseBackoff(1 * time.Second),
+	)
+
+	now := time.Now()
+	ft.RecordFailure("provider-a", now)
+
+	// Should be excluded immediately after failure
+	if !ft.IsExcluded("provider-a", now) {
+		t.Error("should be excluded at t=0")
+	}
+
+	// Should be excluded at t=0.5s
+	if !ft.IsExcluded("provider-a", now.Add(500*time.Millisecond)) {
+		t.Error("should be excluded at t=0.5s")
+	}
+
+	// Should NOT be excluded at t=1.1s (backoff expired)
+	if ft.IsExcluded("provider-a", now.Add(1100*time.Millisecond)) {
+		t.Error("should not be excluded at t=1.1s")
+	}
+}
+
+func TestFailureTracker_SuccessReset(t *testing.T) {
+	ft := NewFailureTracker(
+		WithBaseBackoff(1*time.Second),
+		WithResetAfter(5*time.Second),
+	)
+
+	now := time.Now()
+
+	// Record some failures
+	ft.RecordFailure("provider-a", now)
+	ft.RecordFailure("provider-a", now.Add(2*time.Second))
+	ft.RecordFailure("provider-a", now.Add(4*time.Second))
+
+	if ft.GetFailureCount("provider-a") != 3 {
+		t.Errorf("failure count = %d, want 3", ft.GetFailureCount("provider-a"))
+	}
+
+	// Success too soon - doesn't reset
+	ft.RecordSuccess("provider-a", now.Add(6*time.Second)) // 2s after last failure
+	if ft.GetFailureCount("provider-a") != 3 {
+		t.Errorf("failure count after early success = %d, want 3", ft.GetFailureCount("provider-a"))
+	}
+
+	// Success after resetAfter - resets
+	ft.RecordSuccess("provider-a", now.Add(10*time.Second)) // 6s after last failure
+	if ft.GetFailureCount("provider-a") != 0 {
+		t.Errorf("failure count after reset = %d, want 0", ft.GetFailureCount("provider-a"))
+	}
+}
+
+func TestFailureTracker_MultipleKeys(t *testing.T) {
+	ft := NewFailureTracker(
+		WithBaseBackoff(1 * time.Second),
+	)
+
+	now := time.Now()
+
+	ft.RecordFailure("provider-a", now)
+	ft.RecordFailure("provider-b", now)
+	ft.RecordFailure("provider-a:zone-1", now)
+
+	if ft.GetFailureCount("provider-a") != 1 {
+		t.Errorf("provider-a count = %d, want 1", ft.GetFailureCount("provider-a"))
+	}
+	if ft.GetFailureCount("provider-b") != 1 {
+		t.Errorf("provider-b count = %d, want 1", ft.GetFailureCount("provider-b"))
+	}
+	if ft.GetFailureCount("provider-a:zone-1") != 1 {
+		t.Errorf("provider-a:zone-1 count = %d, want 1", ft.GetFailureCount("provider-a:zone-1"))
+	}
+	if ft.GetFailureCount("provider-c") != 0 {
+		t.Errorf("provider-c count = %d, want 0", ft.GetFailureCount("provider-c"))
+	}
+}
+
+func TestFailureTracker_GetStats(t *testing.T) {
+	ft := NewFailureTracker(
+		WithBaseBackoff(10 * time.Second),
+	)
+
+	now := time.Now()
+	ft.RecordFailure("provider-a", now)
+	ft.RecordFailure("provider-a", now.Add(1*time.Second))
+	ft.RecordFailure("provider-b", now.Add(2*time.Second))
+
+	stats := ft.GetStats(now.Add(3 * time.Second))
+	if len(stats) != 2 {
+		t.Fatalf("stats length = %d, want 2", len(stats))
+	}
+
+	// Find provider-a stats
+	var providerAStats *FailureStats
+	for i := range stats {
+		if stats[i].Key == "provider-a" {
+			providerAStats = &stats[i]
+			break
+		}
+	}
+
+	if providerAStats == nil {
+		t.Fatal("provider-a stats not found")
+	}
+	if providerAStats.FailureCount != 2 {
+		t.Errorf("provider-a failure count = %d, want 2", providerAStats.FailureCount)
+	}
+	if providerAStats.ExcludedFor <= 0 {
+		t.Error("provider-a should still be excluded")
+	}
+}
+
+func TestFailureTracker_Reset(t *testing.T) {
+	ft := NewFailureTracker()
+
+	now := time.Now()
+	ft.RecordFailure("provider-a", now)
+	ft.RecordFailure("provider-b", now)
+
+	ft.Reset()
+
+	if ft.GetFailureCount("provider-a") != 0 {
+		t.Error("provider-a should be reset")
+	}
+	if ft.GetFailureCount("provider-b") != 0 {
+		t.Error("provider-b should be reset")
+	}
+}

--- a/pkg/pool/selector_test.go
+++ b/pkg/pool/selector_test.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/NavarchProject/navarch/pkg/provider"
 )
@@ -193,6 +194,226 @@ func TestNewSelector(t *testing.T) {
 				t.Errorf("NewSelector(%q) error = %v, wantErr %v", tt.strategy, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestFailoverSelector_ExcludesFailingProviders(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	tracker := NewFailureTracker(
+		WithBaseBackoff(10 * time.Second),
+	)
+
+	inner := NewPrioritySelector()
+	selector := NewFailoverSelector(inner,
+		WithFailureTracker(tracker),
+		WithClock(clock),
+	)
+
+	candidates := []ProviderCandidate{
+		{Name: "primary", Priority: 1},
+		{Name: "secondary", Priority: 2},
+	}
+
+	ctx := context.Background()
+
+	// First selection: primary (lowest priority)
+	c, err := selector.Select(ctx, candidates)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if c.Name != "primary" {
+		t.Errorf("Select() = %s, want primary", c.Name)
+	}
+
+	// Record failure for primary
+	selector.RecordFailure("primary", nil)
+
+	// Next selection: still tries primary first (inner selector handles attempts)
+	// But after inner exhausts, we fall back
+	inner.RecordFailure("primary", nil)
+	c, err = selector.Select(ctx, candidates)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if c.Name != "secondary" {
+		t.Errorf("Select() = %s, want secondary", c.Name)
+	}
+
+	// Reset inner selector for next round
+	inner.RecordSuccess("any")
+
+	// Primary should now be excluded due to backoff
+	if !selector.IsProviderExcluded("primary") {
+		t.Error("primary should be excluded")
+	}
+
+	// Selection should skip primary and return secondary
+	c, err = selector.Select(ctx, candidates)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if c.Name != "secondary" {
+		t.Errorf("Select() = %s, want secondary (primary excluded)", c.Name)
+	}
+
+	// After backoff expires, primary should be available again
+	now = now.Add(11 * time.Second)
+	inner.RecordSuccess("any") // Reset inner
+
+	if selector.IsProviderExcluded("primary") {
+		t.Error("primary should not be excluded after backoff")
+	}
+
+	c, err = selector.Select(ctx, candidates)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if c.Name != "primary" {
+		t.Errorf("Select() = %s, want primary (backoff expired)", c.Name)
+	}
+}
+
+func TestFailoverSelector_ZoneFailures(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	tracker := NewFailureTracker(
+		WithBaseBackoff(10 * time.Second),
+	)
+
+	inner := NewPrioritySelector()
+	selector := NewFailoverSelector(inner,
+		WithFailureTracker(tracker),
+		WithClock(clock),
+	)
+
+	// Record zone-specific failure
+	selector.RecordZoneFailure("provider-a", "us-east-1a", nil)
+
+	if !selector.IsZoneExcluded("provider-a", "us-east-1a") {
+		t.Error("zone us-east-1a should be excluded")
+	}
+	if !selector.IsProviderExcluded("provider-a") {
+		t.Error("provider-a should be excluded (zone failure propagates)")
+	}
+
+	// Zone success should recover
+	now = now.Add(15 * time.Second)
+	selector.RecordZoneSuccess("provider-a", "us-east-1a")
+
+	// After success + time, should be available
+	now = now.Add(6 * time.Minute)
+	if selector.IsZoneExcluded("provider-a", "us-east-1a") {
+		t.Error("zone should not be excluded after success")
+	}
+}
+
+func TestFailoverSelector_AllExhaustedReturnsError(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	tracker := NewFailureTracker(
+		WithBaseBackoff(10 * time.Second),
+	)
+
+	inner := NewPrioritySelector()
+	selector := NewFailoverSelector(inner,
+		WithFailureTracker(tracker),
+		WithClock(clock),
+	)
+
+	candidates := []ProviderCandidate{
+		{Name: "a", Priority: 1},
+		{Name: "b", Priority: 2},
+	}
+
+	ctx := context.Background()
+
+	// Fail all providers (marks them as attempted and starts backoff)
+	selector.RecordFailure("a", nil)
+	selector.RecordFailure("b", nil)
+
+	// All providers exhausted - should return error
+	_, err := selector.Select(ctx, candidates)
+	if err == nil {
+		t.Error("Select() should fail when all providers exhausted")
+	}
+
+	// After backoff expires and inner is reset, should work again
+	now = now.Add(15 * time.Second)
+	selector.RecordSuccess("a") // Reset inner selector
+	c, err := selector.Select(ctx, candidates)
+	if err != nil {
+		t.Fatalf("Select() after reset error = %v", err)
+	}
+	if c.Name != "a" {
+		t.Errorf("Select() = %s, want a", c.Name)
+	}
+}
+
+func TestZoneDistributor_EvenDistribution(t *testing.T) {
+	zd := NewZoneDistributor([]string{"a", "b", "c"})
+
+	// First three should go to different zones
+	zones := make(map[string]int)
+	for i := 0; i < 3; i++ {
+		zone := zd.NextZone()
+		zones[zone]++
+		zd.RecordProvisioned(zone)
+	}
+
+	// Each zone should have exactly 1
+	for _, z := range []string{"a", "b", "c"} {
+		if zones[z] != 1 {
+			t.Errorf("zone %s count = %d, want 1", z, zones[z])
+		}
+	}
+
+	// Next three should also distribute evenly
+	for i := 0; i < 3; i++ {
+		zone := zd.NextZone()
+		zones[zone]++
+		zd.RecordProvisioned(zone)
+	}
+
+	// Each zone should now have 2
+	for _, z := range []string{"a", "b", "c"} {
+		if zones[z] != 2 {
+			t.Errorf("zone %s count = %d, want 2", z, zones[z])
+		}
+	}
+}
+
+func TestZoneDistributor_HandleTermination(t *testing.T) {
+	zd := NewZoneDistributor([]string{"a", "b"})
+
+	// Provision 2 in zone a, 1 in zone b
+	zd.RecordProvisioned("a")
+	zd.RecordProvisioned("a")
+	zd.RecordProvisioned("b")
+
+	// Next should go to b (fewer nodes)
+	if zone := zd.NextZone(); zone != "b" {
+		t.Errorf("NextZone() = %s, want b", zone)
+	}
+
+	// Terminate one from a
+	zd.RecordTerminated("a")
+
+	// Now a and b are equal, should return one of them
+	zone := zd.NextZone()
+	if zone != "a" && zone != "b" {
+		t.Errorf("NextZone() = %s, want a or b", zone)
+	}
+}
+
+func TestZoneDistributor_EmptyZones(t *testing.T) {
+	zd := NewZoneDistributor([]string{})
+
+	if zone := zd.NextZone(); zone != "" {
+		t.Errorf("NextZone() = %s, want empty", zone)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Providers that fail repeatedly are temporarily excluded using exponential backoff (30s → 60s → 2m → up to 10m)
- Nodes are distributed across availability zones for high availability
- The default "priority" strategy now includes smart backoff automatically

## Changes

- **FailureTracker**: Tracks provisioning failures per provider/zone with configurable backoff
- **FailoverSelector**: Wraps priority selector and excludes providers in backoff
- **ZoneDistributor**: Ensures even distribution of nodes across AZs
- **Pool integration**: Zone selection and failure recording

## Test plan

- [x] Unit tests for FailureTracker (backoff, exclusion expiry, success reset)
- [x] Unit tests for FailoverSelector (exclusion, zone failures, exhausted providers)
- [x] Unit tests for ZoneDistributor (even distribution, termination handling)
- [x] Existing pool tests still pass
- [x] All tests pass: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)