### PR TITLE
Add preemption detection for spot/preemptible instances

### DIFF
--- a/pkg/preemption/detector.go
+++ b/pkg/preemption/detector.go
@@ -1,0 +1,239 @@
+// Package preemption provides detection of spot/preemptible instance termination notices.
+package preemption
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Status represents the preemption state of an instance.
+type Status struct {
+	Preempted    bool      // True if preemption notice received
+	TerminateAt  time.Time // When the instance will be terminated (zero if not preempted)
+	Provider     string    // Which provider detected the preemption
+	InstanceID   string    // Instance ID (for logging)
+}
+
+// Detector checks for preemption notices from cloud providers.
+type Detector interface {
+	// Check returns the preemption status for this instance.
+	// Returns (status, nil) on success, (nil, error) on failure to check.
+	Check(ctx context.Context) (*Status, error)
+}
+
+// AWSDetector checks AWS spot instance termination notices via IMDS.
+type AWSDetector struct {
+	client     *http.Client
+	instanceID string
+}
+
+// NewAWSDetector creates a detector for AWS spot termination notices.
+func NewAWSDetector(instanceID string) *AWSDetector {
+	return &AWSDetector{
+		client: &http.Client{
+			Timeout: 2 * time.Second,
+		},
+		instanceID: instanceID,
+	}
+}
+
+// Check queries AWS Instance Metadata Service for spot termination notice.
+// AWS provides a 2-minute warning before spot termination.
+func (d *AWSDetector) Check(ctx context.Context) (*Status, error) {
+	// First, get IMDSv2 token
+	tokenReq, err := http.NewRequestWithContext(ctx, "PUT", "http://169.254.169.254/latest/api/token", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	tokenReq.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "60")
+
+	tokenResp, err := d.client.Do(tokenReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get IMDS token: %w", err)
+	}
+	defer tokenResp.Body.Close()
+
+	tokenBytes, err := io.ReadAll(tokenResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token: %w", err)
+	}
+	token := string(tokenBytes)
+
+	// Check for spot termination notice
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		"http://169.254.169.254/latest/meta-data/spot/termination-time", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("X-aws-ec2-metadata-token", token)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check termination notice: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 404 means no termination notice (good!)
+	if resp.StatusCode == http.StatusNotFound {
+		return &Status{
+			Preempted:  false,
+			Provider:   "aws",
+			InstanceID: d.instanceID,
+		}, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	// Parse termination time (format: 2015-01-05T18:02:00Z)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read termination time: %w", err)
+	}
+
+	terminateAt, err := time.Parse(time.RFC3339, strings.TrimSpace(string(body)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse termination time: %w", err)
+	}
+
+	return &Status{
+		Preempted:   true,
+		TerminateAt: terminateAt,
+		Provider:    "aws",
+		InstanceID:  d.instanceID,
+	}, nil
+}
+
+// GCPDetector checks GCP preemptible/spot instance termination notices via metadata.
+type GCPDetector struct {
+	client     *http.Client
+	instanceID string
+}
+
+// NewGCPDetector creates a detector for GCP preemption notices.
+func NewGCPDetector(instanceID string) *GCPDetector {
+	return &GCPDetector{
+		client: &http.Client{
+			Timeout: 2 * time.Second,
+		},
+		instanceID: instanceID,
+	}
+}
+
+// Check queries GCP metadata server for preemption notice.
+// GCP provides a 30-second warning before preemption.
+func (d *GCPDetector) Check(ctx context.Context) (*Status, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		"http://metadata.google.internal/computeMetadata/v1/instance/preempted", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check preemption: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	preempted := strings.TrimSpace(string(body)) == "TRUE"
+
+	status := &Status{
+		Preempted:  preempted,
+		Provider:   "gcp",
+		InstanceID: d.instanceID,
+	}
+
+	if preempted {
+		// GCP gives ~30 seconds warning
+		status.TerminateAt = time.Now().Add(30 * time.Second)
+	}
+
+	return status, nil
+}
+
+// MultiDetector tries multiple detectors and returns the first successful result.
+// Useful when you don't know which cloud you're running on.
+type MultiDetector struct {
+	detectors []Detector
+}
+
+// NewMultiDetector creates a detector that tries multiple providers.
+func NewMultiDetector(instanceID string) *MultiDetector {
+	return &MultiDetector{
+		detectors: []Detector{
+			NewAWSDetector(instanceID),
+			NewGCPDetector(instanceID),
+		},
+	}
+}
+
+// Check tries each detector until one succeeds.
+func (d *MultiDetector) Check(ctx context.Context) (*Status, error) {
+	var lastErr error
+	for _, detector := range d.detectors {
+		status, err := detector.Check(ctx)
+		if err == nil {
+			return status, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("all detectors failed, last error: %w", lastErr)
+}
+
+// Watcher continuously monitors for preemption and notifies via callback.
+type Watcher struct {
+	detector Detector
+	interval time.Duration
+	onPreempt func(Status)
+}
+
+// NewWatcher creates a preemption watcher.
+func NewWatcher(detector Detector, interval time.Duration, onPreempt func(Status)) *Watcher {
+	if interval == 0 {
+		interval = 5 * time.Second
+	}
+	return &Watcher{
+		detector:  detector,
+		interval:  interval,
+		onPreempt: onPreempt,
+	}
+}
+
+// Watch starts watching for preemption notices.
+// Blocks until context is cancelled or preemption is detected.
+func (w *Watcher) Watch(ctx context.Context) error {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			status, err := w.detector.Check(ctx)
+			if err != nil {
+				// Log but continue - metadata service might be temporarily unavailable
+				continue
+			}
+			if status.Preempted {
+				w.onPreempt(*status)
+				return nil
+			}
+		}
+	}
+}

--- a/pkg/preemption/detector_test.go
+++ b/pkg/preemption/detector_test.go
@@ -1,0 +1,293 @@
+package preemption
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAWSDetector_NoPreemption(t *testing.T) {
+	// Mock IMDS server
+	tokenHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("expected PUT for token, got %s", r.Method)
+		}
+		w.Write([]byte("mock-token"))
+	})
+
+	termHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-aws-ec2-metadata-token") != "mock-token" {
+			t.Error("missing or wrong token header")
+		}
+		// 404 means no termination notice
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle("/latest/api/token", tokenHandler)
+	mux.Handle("/latest/meta-data/spot/termination-time", termHandler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	detector := &AWSDetector{
+		client:     server.Client(),
+		instanceID: "i-12345",
+	}
+	// Override the IMDS URL by using a custom transport
+	detector.client.Transport = &urlRewriteTransport{
+		base:    http.DefaultTransport,
+		fromURL: "http://169.254.169.254",
+		toURL:   server.URL,
+	}
+
+	status, err := detector.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.Preempted {
+		t.Error("expected Preempted=false")
+	}
+	if status.Provider != "aws" {
+		t.Errorf("expected provider=aws, got %s", status.Provider)
+	}
+	if status.InstanceID != "i-12345" {
+		t.Errorf("expected instanceID=i-12345, got %s", status.InstanceID)
+	}
+}
+
+func TestAWSDetector_Preempted(t *testing.T) {
+	terminateTime := time.Now().Add(2 * time.Minute).UTC().Format(time.RFC3339)
+
+	tokenHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("mock-token"))
+	})
+
+	termHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(terminateTime))
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle("/latest/api/token", tokenHandler)
+	mux.Handle("/latest/meta-data/spot/termination-time", termHandler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	detector := &AWSDetector{
+		client:     server.Client(),
+		instanceID: "i-12345",
+	}
+	detector.client.Transport = &urlRewriteTransport{
+		base:    http.DefaultTransport,
+		fromURL: "http://169.254.169.254",
+		toURL:   server.URL,
+	}
+
+	status, err := detector.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !status.Preempted {
+		t.Error("expected Preempted=true")
+	}
+	if status.TerminateAt.IsZero() {
+		t.Error("expected non-zero TerminateAt")
+	}
+}
+
+func TestGCPDetector_NoPreemption(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			t.Error("missing Metadata-Flavor header")
+		}
+		w.Write([]byte("FALSE"))
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	detector := &GCPDetector{
+		client:     server.Client(),
+		instanceID: "gcp-12345",
+	}
+	detector.client.Transport = &urlRewriteTransport{
+		base:    http.DefaultTransport,
+		fromURL: "http://metadata.google.internal",
+		toURL:   server.URL,
+	}
+
+	status, err := detector.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.Preempted {
+		t.Error("expected Preempted=false")
+	}
+	if status.Provider != "gcp" {
+		t.Errorf("expected provider=gcp, got %s", status.Provider)
+	}
+}
+
+func TestGCPDetector_Preempted(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("TRUE"))
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	detector := &GCPDetector{
+		client:     server.Client(),
+		instanceID: "gcp-12345",
+	}
+	detector.client.Transport = &urlRewriteTransport{
+		base:    http.DefaultTransport,
+		fromURL: "http://metadata.google.internal",
+		toURL:   server.URL,
+	}
+
+	status, err := detector.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !status.Preempted {
+		t.Error("expected Preempted=true")
+	}
+	// GCP gives ~30 second warning, so TerminateAt should be set
+	if status.TerminateAt.IsZero() {
+		t.Error("expected non-zero TerminateAt")
+	}
+}
+
+func TestMultiDetector_FirstSuccess(t *testing.T) {
+	detector := &MultiDetector{
+		detectors: []Detector{
+			&mockDetector{err: nil, status: &Status{Provider: "mock1", Preempted: false}},
+			&mockDetector{err: nil, status: &Status{Provider: "mock2", Preempted: false}},
+		},
+	}
+
+	status, err := detector.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.Provider != "mock1" {
+		t.Errorf("expected first detector result, got provider=%s", status.Provider)
+	}
+}
+
+func TestMultiDetector_Fallback(t *testing.T) {
+	detector := &MultiDetector{
+		detectors: []Detector{
+			&mockDetector{err: context.DeadlineExceeded, status: nil},
+			&mockDetector{err: nil, status: &Status{Provider: "mock2", Preempted: false}},
+		},
+	}
+
+	status, err := detector.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.Provider != "mock2" {
+		t.Errorf("expected second detector result, got provider=%s", status.Provider)
+	}
+}
+
+func TestMultiDetector_AllFail(t *testing.T) {
+	detector := &MultiDetector{
+		detectors: []Detector{
+			&mockDetector{err: context.DeadlineExceeded, status: nil},
+			&mockDetector{err: context.Canceled, status: nil},
+		},
+	}
+
+	_, err := detector.Check(context.Background())
+	if err == nil {
+		t.Error("expected error when all detectors fail")
+	}
+}
+
+func TestWatcher_DetectsPreemption(t *testing.T) {
+	callCount := 0
+	detector := &mockDetector{
+		checkFunc: func() (*Status, error) {
+			callCount++
+			if callCount >= 3 {
+				return &Status{Preempted: true, Provider: "mock"}, nil
+			}
+			return &Status{Preempted: false, Provider: "mock"}, nil
+		},
+	}
+
+	var receivedStatus Status
+	watcher := NewWatcher(detector, 10*time.Millisecond, func(s Status) {
+		receivedStatus = s
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := watcher.Watch(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !receivedStatus.Preempted {
+		t.Error("expected preemption callback to be called")
+	}
+	if callCount < 3 {
+		t.Errorf("expected at least 3 checks, got %d", callCount)
+	}
+}
+
+func TestWatcher_ContextCancellation(t *testing.T) {
+	detector := &mockDetector{
+		status: &Status{Preempted: false, Provider: "mock"},
+	}
+
+	watcher := NewWatcher(detector, 10*time.Millisecond, func(s Status) {
+		t.Error("callback should not be called")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately
+	cancel()
+
+	err := watcher.Watch(ctx)
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// mockDetector for testing
+type mockDetector struct {
+	status    *Status
+	err       error
+	checkFunc func() (*Status, error)
+}
+
+func (m *mockDetector) Check(ctx context.Context) (*Status, error) {
+	if m.checkFunc != nil {
+		return m.checkFunc()
+	}
+	return m.status, m.err
+}
+
+// urlRewriteTransport rewrites URLs for testing
+type urlRewriteTransport struct {
+	base    http.RoundTripper
+	fromURL string
+	toURL   string
+}
+
+func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rewrite the URL
+	newURL := t.toURL + req.URL.Path
+	newReq, err := http.NewRequestWithContext(req.Context(), req.Method, newURL, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	newReq.Header = req.Header
+	return t.base.RoundTrip(newReq)
+}

--- a/proto/control_plane.proto
+++ b/proto/control_plane.proto
@@ -387,6 +387,21 @@ message HeartbeatRequest {
 
   // Optional basic metrics (lightweight, doesn't require health checks).
   NodeMetrics metrics = 3;
+
+  // Preemption status (for spot/preemptible instances).
+  PreemptionStatus preemption = 4;
+}
+
+// PreemptionStatus reports spot/preemptible instance termination notice.
+message PreemptionStatus {
+  // True if a preemption notice has been received.
+  bool preempted = 1;
+
+  // When the instance will be terminated (if preempted).
+  google.protobuf.Timestamp terminate_at = 2;
+
+  // Which provider detected the preemption (e.g., "aws", "gcp").
+  string provider = 3;
 }
 
 // HeartbeatResponse acknowledges receipt of heartbeat.


### PR DESCRIPTION
## Summary

- Add `pkg/preemption` package with AWS and GCP preemption detectors
- Integrate preemption monitoring into node agent for spot instances
- Report preemption status in heartbeats to control plane
- Mark preempted nodes as DRAINING so pools can provision replacements

## Details

**AWS Spot Detection:**
- Uses IMDSv2 to check `/latest/meta-data/spot/termination-time`
- Provides 2-minute warning before termination

**GCP Preemptible Detection:**
- Checks `metadata.google.internal/computeMetadata/v1/instance/preempted`
- Provides ~30-second warning before termination

**Node Agent:**
- New `Spot` field in Config enables preemption monitoring
- Preemption watcher runs alongside heartbeat/health loops
- Immediate heartbeat sent when preemption detected

**Control Plane:**
- Logs preemption notices for observability
- Marks nodes as DRAINING to trigger replacement provisioning

## Test plan

- [x] Unit tests for AWS detector with mock IMDS
- [x] Unit tests for GCP detector with mock metadata server
- [x] Unit tests for MultiDetector fallback behavior
- [x] Unit tests for Watcher preemption callback
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)