### PR TITLE
Add YAML config parsing for job definitions

### DIFF
--- a/pkg/config/job.go
+++ b/pkg/config/job.go
@@ -1,0 +1,282 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JobConfig defines a task or job to run on GPU instances.
+// Used by `navarch run` and `navarch dev` commands.
+type JobConfig struct {
+	// Name is an optional identifier for the job.
+	Name string `yaml:"name,omitempty"`
+
+	// Resources specifies GPU and compute requirements.
+	Resources ResourcesCfg `yaml:"resources,omitempty"`
+
+	// Run is the command or script to execute.
+	// Can be a single command string or multi-line script.
+	Run string `yaml:"run,omitempty"`
+
+	// Setup contains commands to run before the main task.
+	// Useful for installing dependencies, downloading data, etc.
+	Setup string `yaml:"setup,omitempty"`
+
+	// Envs are environment variables to set.
+	Envs map[string]string `yaml:"envs,omitempty"`
+
+	// WorkDir is the local directory to sync to the instance.
+	// Defaults to current directory.
+	WorkDir string `yaml:"workdir,omitempty"`
+
+	// Image is the Docker image to use.
+	// If not specified, runs on bare metal with system Python.
+	Image string `yaml:"image,omitempty"`
+
+	// Ports to expose (for dev mode).
+	Ports []int `yaml:"ports,omitempty"`
+
+	// Spot enables spot/preemptible instances for cost savings.
+	Spot bool `yaml:"spot,omitempty"`
+
+	// Pool specifies which pool to use (if multiple pools exist).
+	Pool string `yaml:"pool,omitempty"`
+}
+
+// ResourcesCfg specifies compute resource requirements.
+type ResourcesCfg struct {
+	// GPU specifies GPU requirements.
+	// Can be: "H100", "H100:8", "A100", "any", etc.
+	GPU string `yaml:"gpu,omitempty"`
+
+	// GPUCount specifies number of GPUs (alternative to GPU suffix).
+	GPUCount int `yaml:"gpu_count,omitempty"`
+
+	// Memory specifies minimum memory (e.g., "64GB").
+	Memory string `yaml:"memory,omitempty"`
+
+	// CPUs specifies minimum vCPUs.
+	CPUs int `yaml:"cpus,omitempty"`
+
+	// Cloud restricts to specific cloud provider(s).
+	// Can be: "aws", "gcp", "lambda", or comma-separated list.
+	Cloud string `yaml:"cloud,omitempty"`
+
+	// Region restricts to specific region(s).
+	Region string `yaml:"region,omitempty"`
+
+	// Zone restricts to specific zone(s).
+	Zone string `yaml:"zone,omitempty"`
+}
+
+// LoadJob reads a job configuration from a YAML file.
+func LoadJob(path string) (*JobConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading job config: %w", err)
+	}
+
+	var job JobConfig
+	if err := yaml.Unmarshal(data, &job); err != nil {
+		return nil, fmt.Errorf("parsing job config: %w", err)
+	}
+
+	if err := job.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid job config: %w", err)
+	}
+
+	job.applyDefaults()
+	return &job, nil
+}
+
+// LoadJobFromString parses a job configuration from YAML string.
+func LoadJobFromString(data string) (*JobConfig, error) {
+	var job JobConfig
+	if err := yaml.Unmarshal([]byte(data), &job); err != nil {
+		return nil, fmt.Errorf("parsing job config: %w", err)
+	}
+
+	if err := job.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid job config: %w", err)
+	}
+
+	job.applyDefaults()
+	return &job, nil
+}
+
+// Validate checks the job configuration for errors.
+func (j *JobConfig) Validate() error {
+	// At minimum, a job needs either a run command or to be a dev session
+	// (dev sessions don't require a run command since they're interactive)
+	// This validation is minimal - more validation happens at runtime
+
+	if j.Resources.GPU != "" {
+		if err := validateGPUSpec(j.Resources.GPU); err != nil {
+			return err
+		}
+	}
+
+	if j.Resources.Memory != "" {
+		if err := validateMemorySpec(j.Resources.Memory); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (j *JobConfig) applyDefaults() {
+	if j.WorkDir == "" {
+		j.WorkDir = "."
+	}
+}
+
+// ParseGPU parses a GPU specification string and returns GPU type and count.
+// Examples: "H100" -> ("H100", 1), "H100:8" -> ("H100", 8), "any:4" -> ("any", 4)
+func (r *ResourcesCfg) ParseGPU() (gpuType string, count int) {
+	if r.GPU == "" {
+		return "", r.GPUCount
+	}
+
+	parts := strings.SplitN(r.GPU, ":", 2)
+	gpuType = parts[0]
+	count = 1
+
+	if len(parts) == 2 {
+		fmt.Sscanf(parts[1], "%d", &count)
+	}
+
+	// GPUCount takes precedence if specified
+	if r.GPUCount > 0 {
+		count = r.GPUCount
+	}
+
+	return gpuType, count
+}
+
+// ParseMemoryGB parses memory specification and returns gigabytes.
+// Examples: "64GB" -> 64, "128G" -> 128, "256" -> 256
+func (r *ResourcesCfg) ParseMemoryGB() int {
+	if r.Memory == "" {
+		return 0
+	}
+
+	mem := strings.TrimSpace(strings.ToUpper(r.Memory))
+	mem = strings.TrimSuffix(mem, "GB")
+	mem = strings.TrimSuffix(mem, "G")
+
+	var gb int
+	fmt.Sscanf(mem, "%d", &gb)
+	return gb
+}
+
+// ParseClouds returns the list of allowed cloud providers.
+func (r *ResourcesCfg) ParseClouds() []string {
+	if r.Cloud == "" {
+		return nil
+	}
+
+	clouds := strings.Split(r.Cloud, ",")
+	for i := range clouds {
+		clouds[i] = strings.TrimSpace(strings.ToLower(clouds[i]))
+	}
+	return clouds
+}
+
+// ParseRegions returns the list of allowed regions.
+func (r *ResourcesCfg) ParseRegions() []string {
+	if r.Region == "" {
+		return nil
+	}
+
+	regions := strings.Split(r.Region, ",")
+	for i := range regions {
+		regions[i] = strings.TrimSpace(regions[i])
+	}
+	return regions
+}
+
+func validateGPUSpec(spec string) error {
+	parts := strings.SplitN(spec, ":", 2)
+	gpuType := strings.ToUpper(parts[0])
+
+	// Valid GPU types (common ones)
+	validTypes := map[string]bool{
+		"ANY":   true,
+		"H100":  true,
+		"A100":  true,
+		"A10G":  true,
+		"L4":    true,
+		"L40S":  true,
+		"V100":  true,
+		"T4":    true,
+		"A6000": true,
+		"RTX":   true, // Allow RTX* pattern
+	}
+
+	// Check if type is valid or starts with a valid prefix
+	if !validTypes[gpuType] && !strings.HasPrefix(gpuType, "RTX") {
+		// Allow unknown types with a warning (flexibility for new GPUs)
+	}
+
+	if len(parts) == 2 {
+		var count int
+		if _, err := fmt.Sscanf(parts[1], "%d", &count); err != nil || count <= 0 {
+			return fmt.Errorf("invalid GPU count in %q: must be positive integer", spec)
+		}
+	}
+
+	return nil
+}
+
+func validateMemorySpec(spec string) error {
+	mem := strings.TrimSpace(strings.ToUpper(spec))
+	mem = strings.TrimSuffix(mem, "GB")
+	mem = strings.TrimSuffix(mem, "G")
+
+	var gb int
+	if _, err := fmt.Sscanf(mem, "%d", &gb); err != nil || gb <= 0 {
+		return fmt.Errorf("invalid memory specification %q: must be positive integer with optional GB suffix", spec)
+	}
+
+	return nil
+}
+
+// FindJobConfig looks for a job configuration file in standard locations.
+// Checks: navarch.yaml, navarch.yml, .navarch.yaml, .navarch.yml
+func FindJobConfig() (string, error) {
+	candidates := []string{
+		"navarch.yaml",
+		"navarch.yml",
+		".navarch.yaml",
+		".navarch.yml",
+	}
+
+	for _, name := range candidates {
+		if _, err := os.Stat(name); err == nil {
+			return name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no job config found (tried: %s)", strings.Join(candidates, ", "))
+}
+
+// ResolveWorkDir resolves the workdir path relative to the config file.
+func (j *JobConfig) ResolveWorkDir(configPath string) (string, error) {
+	if filepath.IsAbs(j.WorkDir) {
+		return j.WorkDir, nil
+	}
+
+	// If config path is provided, resolve relative to it
+	if configPath != "" {
+		configDir := filepath.Dir(configPath)
+		return filepath.Join(configDir, j.WorkDir), nil
+	}
+
+	// Otherwise resolve relative to cwd
+	return filepath.Abs(j.WorkDir)
+}

--- a/pkg/config/job_test.go
+++ b/pkg/config/job_test.go
@@ -1,0 +1,317 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadJobFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+		check   func(*testing.T, *JobConfig)
+	}{
+		{
+			name: "minimal config",
+			yaml: `
+run: python train.py
+`,
+			wantErr: false,
+			check: func(t *testing.T, j *JobConfig) {
+				if j.Run != "python train.py" {
+					t.Errorf("expected run='python train.py', got %q", j.Run)
+				}
+				if j.WorkDir != "." {
+					t.Errorf("expected default workdir='.', got %q", j.WorkDir)
+				}
+			},
+		},
+		{
+			name: "full config",
+			yaml: `
+name: training-job
+resources:
+  gpu: H100:8
+  memory: 128GB
+  cpus: 32
+  cloud: aws,gcp
+  region: us-east-1,us-west-2
+run: |
+  cd /workspace
+  python train.py --epochs 100
+setup: |
+  pip install -r requirements.txt
+envs:
+  WANDB_API_KEY: secret
+  CUDA_VISIBLE_DEVICES: "0,1,2,3"
+workdir: ./src
+image: pytorch/pytorch:2.0-cuda11.8
+ports:
+  - 8888
+  - 6006
+spot: true
+pool: training
+`,
+			wantErr: false,
+			check: func(t *testing.T, j *JobConfig) {
+				if j.Name != "training-job" {
+					t.Errorf("expected name='training-job', got %q", j.Name)
+				}
+				if j.Resources.GPU != "H100:8" {
+					t.Errorf("expected gpu='H100:8', got %q", j.Resources.GPU)
+				}
+				if j.Resources.Memory != "128GB" {
+					t.Errorf("expected memory='128GB', got %q", j.Resources.Memory)
+				}
+				if j.Resources.CPUs != 32 {
+					t.Errorf("expected cpus=32, got %d", j.Resources.CPUs)
+				}
+				if !j.Spot {
+					t.Error("expected spot=true")
+				}
+				if j.Pool != "training" {
+					t.Errorf("expected pool='training', got %q", j.Pool)
+				}
+				if len(j.Ports) != 2 {
+					t.Errorf("expected 2 ports, got %d", len(j.Ports))
+				}
+				if j.Image != "pytorch/pytorch:2.0-cuda11.8" {
+					t.Errorf("expected image='pytorch/pytorch:2.0-cuda11.8', got %q", j.Image)
+				}
+			},
+		},
+		{
+			name: "gpu count alternative",
+			yaml: `
+resources:
+  gpu: A100
+  gpu_count: 4
+run: python train.py
+`,
+			wantErr: false,
+			check: func(t *testing.T, j *JobConfig) {
+				gpuType, count := j.Resources.ParseGPU()
+				if gpuType != "A100" {
+					t.Errorf("expected gpu type='A100', got %q", gpuType)
+				}
+				if count != 4 {
+					t.Errorf("expected gpu count=4, got %d", count)
+				}
+			},
+		},
+		{
+			name: "invalid gpu count",
+			yaml: `
+resources:
+  gpu: H100:invalid
+run: test
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid memory",
+			yaml: `
+resources:
+  memory: invalid
+run: test
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job, err := LoadJobFromString(tt.yaml)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, job)
+			}
+		})
+	}
+}
+
+func TestResourcesCfg_ParseGPU(t *testing.T) {
+	tests := []struct {
+		gpu       string
+		gpuCount  int
+		wantType  string
+		wantCount int
+	}{
+		{"H100", 0, "H100", 1},
+		{"H100:8", 0, "H100", 8},
+		{"A100:4", 0, "A100", 4},
+		{"any", 0, "any", 1},
+		{"any:2", 0, "any", 2},
+		{"", 4, "", 4},
+		{"H100", 8, "H100", 8}, // GPUCount takes precedence
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.gpu, func(t *testing.T) {
+			r := ResourcesCfg{GPU: tt.gpu, GPUCount: tt.gpuCount}
+			gotType, gotCount := r.ParseGPU()
+			if gotType != tt.wantType {
+				t.Errorf("ParseGPU() type = %q, want %q", gotType, tt.wantType)
+			}
+			if gotCount != tt.wantCount {
+				t.Errorf("ParseGPU() count = %d, want %d", gotCount, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestResourcesCfg_ParseMemoryGB(t *testing.T) {
+	tests := []struct {
+		memory string
+		want   int
+	}{
+		{"64GB", 64},
+		{"128G", 128},
+		{"256", 256},
+		{"64gb", 64},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.memory, func(t *testing.T) {
+			r := ResourcesCfg{Memory: tt.memory}
+			if got := r.ParseMemoryGB(); got != tt.want {
+				t.Errorf("ParseMemoryGB() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourcesCfg_ParseClouds(t *testing.T) {
+	tests := []struct {
+		cloud string
+		want  []string
+	}{
+		{"aws", []string{"aws"}},
+		{"aws,gcp", []string{"aws", "gcp"}},
+		{"AWS, GCP, Lambda", []string{"aws", "gcp", "lambda"}},
+		{"", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cloud, func(t *testing.T) {
+			r := ResourcesCfg{Cloud: tt.cloud}
+			got := r.ParseClouds()
+			if len(got) != len(tt.want) {
+				t.Errorf("ParseClouds() = %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ParseClouds()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLoadJob(t *testing.T) {
+	// Create a temporary job config file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "navarch.yaml")
+
+	content := `
+name: test-job
+resources:
+  gpu: H100:4
+run: python train.py
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	job, err := LoadJob(configPath)
+	if err != nil {
+		t.Fatalf("LoadJob() error: %v", err)
+	}
+
+	if job.Name != "test-job" {
+		t.Errorf("expected name='test-job', got %q", job.Name)
+	}
+	if job.Resources.GPU != "H100:4" {
+		t.Errorf("expected gpu='H100:4', got %q", job.Resources.GPU)
+	}
+}
+
+func TestFindJobConfig(t *testing.T) {
+	// Save current dir and change to temp
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	// No config should fail
+	_, err := FindJobConfig()
+	if err == nil {
+		t.Error("expected error when no config exists")
+	}
+
+	// Create navarch.yaml
+	if err := os.WriteFile("navarch.yaml", []byte("run: test"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	path, err := FindJobConfig()
+	if err != nil {
+		t.Errorf("FindJobConfig() error: %v", err)
+	}
+	if path != "navarch.yaml" {
+		t.Errorf("FindJobConfig() = %q, want 'navarch.yaml'", path)
+	}
+}
+
+func TestJobConfig_ResolveWorkDir(t *testing.T) {
+	tests := []struct {
+		name       string
+		workDir    string
+		configPath string
+		wantSuffix string
+	}{
+		{
+			name:       "relative to config",
+			workDir:    "src",
+			configPath: "/home/user/project/navarch.yaml",
+			wantSuffix: "/home/user/project/src",
+		},
+		{
+			name:       "absolute path unchanged",
+			workDir:    "/absolute/path",
+			configPath: "/home/user/navarch.yaml",
+			wantSuffix: "/absolute/path",
+		},
+		{
+			name:       "current dir",
+			workDir:    ".",
+			configPath: "/home/user/navarch.yaml",
+			wantSuffix: "/home/user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := &JobConfig{WorkDir: tt.workDir}
+			got, err := j.ResolveWorkDir(tt.configPath)
+			if err != nil {
+				t.Fatalf("ResolveWorkDir() error: %v", err)
+			}
+			if got != tt.wantSuffix {
+				t.Errorf("ResolveWorkDir() = %q, want %q", got, tt.wantSuffix)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `JobConfig` type for `navarch run` and `navarch dev` commands
- Parse GPU requirements (e.g., `H100:8`, `A100:4`)
- Parse memory requirements (e.g., `128GB`)
- Support cloud/region/zone constraints
- Auto-discover `navarch.yaml` config files

## Example Config

```yaml
name: training-job
resources:
  gpu: H100:8
  memory: 128GB
  cloud: aws,gcp
run: |
  python train.py --epochs 100
setup: |
  pip install -r requirements.txt
envs:
  WANDB_API_KEY: secret
workdir: ./src
spot: true
```

## Features

- **Resources**: GPU type/count, memory, CPUs, cloud/region constraints
- **Commands**: `run` for main task, `setup` for dependencies
- **Environment**: Custom env vars, Docker image support
- **Ports**: Forward ports for dev mode (Jupyter, TensorBoard)
- **Workdir**: Local directory to sync to instance

## Test plan

- [x] Parse minimal configs
- [x] Parse full configs with all options
- [x] Parse GPU specs (H100, H100:8, any:4)
- [x] Parse memory specs (64GB, 128G)
- [x] Parse cloud/region lists
- [x] Validate invalid GPU counts
- [x] Validate invalid memory specs
- [x] Auto-discover config files
- [x] Resolve workdir paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)