### PR TITLE
Add navarch dev command for interactive development sessions

### DIFF
--- a/cmd/navarch/dev.go
+++ b/cmd/navarch/dev.go
@@ -1,0 +1,361 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	"github.com/NavarchProject/navarch/pkg/config"
+	"github.com/NavarchProject/navarch/pkg/sync"
+	pb "github.com/NavarchProject/navarch/proto"
+)
+
+var (
+	devConfigFile string
+	devGPU        string
+	devPool       string
+	devSSHKey     string
+	devSSHUser    string
+	devNoSync     bool
+	devWorkdir    string
+	devPorts      []int
+)
+
+func devCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dev",
+		Short: "Start an interactive development session on a GPU instance",
+		Long: `Start an interactive SSH session on a GPU instance.
+
+Code is synced to /workspace on the remote instance. Port forwarding can be
+configured for Jupyter, TensorBoard, and other services.
+
+Examples:
+  # Start dev session with auto-detected config
+  navarch dev
+
+  # Start with port forwarding for Jupyter and TensorBoard
+  navarch dev --port 8888 --port 6006
+
+  # Start on specific pool with GPU
+  navarch dev --pool training --gpu H100`,
+		RunE: runDev,
+	}
+
+	cmd.Flags().StringVarP(&devConfigFile, "file", "f", "", "Config file (default: auto-detect navarch.yaml)")
+	cmd.Flags().StringVar(&devGPU, "gpu", "", "GPU type requirement (e.g., H100, A100:4)")
+	cmd.Flags().StringVar(&devPool, "pool", "", "Pool to use")
+	cmd.Flags().StringVar(&devSSHKey, "ssh-key", "", "SSH private key path")
+	cmd.Flags().StringVar(&devSSHUser, "ssh-user", "ubuntu", "SSH user")
+	cmd.Flags().BoolVar(&devNoSync, "no-sync", false, "Skip code sync")
+	cmd.Flags().StringVar(&devWorkdir, "workdir", ".", "Local directory to sync")
+	cmd.Flags().IntSliceVarP(&devPorts, "port", "p", nil, "Ports to forward (can be specified multiple times)")
+
+	return cmd
+}
+
+func runDev(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle Ctrl+C gracefully
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		fmt.Println("\nClosing dev session...")
+		cancel()
+	}()
+
+	// Load job config
+	jobCfg, err := loadDevConfig()
+	if err != nil {
+		return err
+	}
+
+	// Get a node to develop on
+	node, err := selectDevNode(ctx, jobCfg)
+	if err != nil {
+		return fmt.Errorf("failed to select node: %w", err)
+	}
+
+	ip := getDevNodeIP(node)
+	fmt.Printf("Selected node: %s (%s)\n", node.NodeId, ip)
+
+	// Sync code if not disabled
+	if !devNoSync {
+		fmt.Println("Syncing code...")
+		if err := syncDevCode(ctx, node, jobCfg); err != nil {
+			return fmt.Errorf("failed to sync code: %w", err)
+		}
+		fmt.Println("Code sync complete")
+	}
+
+	// Run setup commands if any
+	if jobCfg.Setup != "" {
+		fmt.Println("Running setup...")
+		if err := runSetup(ctx, node, jobCfg); err != nil {
+			return fmt.Errorf("setup failed: %w", err)
+		}
+		fmt.Println("Setup complete")
+	}
+
+	// Print connection info
+	fmt.Println("---")
+	fmt.Printf("Working directory: /workspace\n")
+	if len(devPorts) > 0 || len(jobCfg.Ports) > 0 {
+		fmt.Printf("Port forwarding:\n")
+		for _, p := range append(devPorts, jobCfg.Ports...) {
+			fmt.Printf("  localhost:%d -> %s:%d\n", p, ip, p)
+		}
+	}
+	fmt.Println("---")
+	fmt.Println("Starting interactive session (Ctrl+D or 'exit' to close)")
+	fmt.Println()
+
+	// Start interactive SSH session
+	return startInteractiveSSH(ctx, node, jobCfg)
+}
+
+func loadDevConfig() (*config.JobConfig, error) {
+	// Try to load from config file
+	if devConfigFile != "" {
+		return config.LoadJob(devConfigFile)
+	}
+
+	// Try auto-detect
+	configPath, err := config.FindJobConfig()
+	if err == nil {
+		job, err := config.LoadJob(configPath)
+		if err != nil {
+			return nil, err
+		}
+		applyDevFlags(job)
+		return job, nil
+	}
+
+	// Create job from CLI flags
+	job := &config.JobConfig{
+		WorkDir: devWorkdir,
+		Ports:   devPorts,
+	}
+
+	if devGPU != "" {
+		job.Resources.GPU = devGPU
+	}
+
+	if devPool != "" {
+		job.Pool = devPool
+	}
+
+	return job, nil
+}
+
+func applyDevFlags(job *config.JobConfig) {
+	if devGPU != "" {
+		job.Resources.GPU = devGPU
+	}
+	if devPool != "" {
+		job.Pool = devPool
+	}
+	if devWorkdir != "." {
+		job.WorkDir = devWorkdir
+	}
+	if len(devPorts) > 0 {
+		job.Ports = devPorts
+	}
+}
+
+func selectDevNode(ctx context.Context, job *config.JobConfig) (*pb.NodeInfo, error) {
+	client := newClient()
+
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req := connect.NewRequest(&pb.ListNodesRequest{})
+	resp, err := client.ListNodes(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	if len(resp.Msg.Nodes) == 0 {
+		return nil, fmt.Errorf("no nodes available")
+	}
+
+	// Filter nodes
+	var candidates []*pb.NodeInfo
+	for _, node := range resp.Msg.Nodes {
+		// Must be active
+		if node.Status != pb.NodeStatus_NODE_STATUS_ACTIVE {
+			continue
+		}
+
+		// Must have IP address
+		ip := getDevNodeIP(node)
+		if ip == "" {
+			continue
+		}
+
+		// Filter by pool if specified
+		if job.Pool != "" {
+			if node.Metadata == nil {
+				continue
+			}
+			poolLabel, ok := node.Metadata.Labels["pool"]
+			if !ok || poolLabel != job.Pool {
+				continue
+			}
+		}
+
+		// Filter by GPU type if specified
+		if job.Resources.GPU != "" {
+			gpuType, _ := job.Resources.ParseGPU()
+			if gpuType != "" && gpuType != "any" {
+				hasMatch := false
+				for _, gpu := range node.Gpus {
+					if strings.Contains(strings.ToUpper(gpu.Name), strings.ToUpper(gpuType)) {
+						hasMatch = true
+						break
+					}
+				}
+				if !hasMatch {
+					continue
+				}
+			}
+		}
+
+		candidates = append(candidates, node)
+	}
+
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no suitable nodes found (pool=%q, gpu=%q)", job.Pool, job.Resources.GPU)
+	}
+
+	return candidates[0], nil
+}
+
+func getDevNodeIP(node *pb.NodeInfo) string {
+	if node.Metadata == nil {
+		return ""
+	}
+	if node.Metadata.ExternalIp != "" {
+		return node.Metadata.ExternalIp
+	}
+	return node.Metadata.InternalIp
+}
+
+func syncDevCode(ctx context.Context, node *pb.NodeInfo, job *config.JobConfig) error {
+	sshKey := devSSHKey
+	if sshKey == "" {
+		homeDir, _ := os.UserHomeDir()
+		candidates := []string{
+			homeDir + "/.ssh/id_ed25519",
+			homeDir + "/.ssh/id_rsa",
+		}
+		for _, path := range candidates {
+			if _, err := os.Stat(path); err == nil {
+				sshKey = path
+				break
+			}
+		}
+	}
+
+	if sshKey == "" {
+		return fmt.Errorf("no SSH key found, specify with --ssh-key")
+	}
+
+	workdir := job.WorkDir
+	if workdir == "" {
+		workdir = "."
+	}
+
+	if !strings.HasPrefix(workdir, "/") {
+		cwd, _ := os.Getwd()
+		workdir = cwd + "/" + workdir
+	}
+
+	ip := getDevNodeIP(node)
+
+	return sync.SyncToNode(ctx, workdir, devSSHUser, ip, 22, sshKey, "/workspace")
+}
+
+func runSetup(ctx context.Context, node *pb.NodeInfo, job *config.JobConfig) error {
+	sshKey := devSSHKey
+	if sshKey == "" {
+		homeDir, _ := os.UserHomeDir()
+		sshKey = homeDir + "/.ssh/id_ed25519"
+	}
+
+	ip := getDevNodeIP(node)
+	setupCmd := fmt.Sprintf("cd /workspace && %s", job.Setup)
+
+	sshArgs := []string{
+		"-i", sshKey,
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		fmt.Sprintf("%s@%s", devSSHUser, ip),
+		setupCmd,
+	}
+
+	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func startInteractiveSSH(ctx context.Context, node *pb.NodeInfo, job *config.JobConfig) error {
+	sshKey := devSSHKey
+	if sshKey == "" {
+		homeDir, _ := os.UserHomeDir()
+		sshKey = homeDir + "/.ssh/id_ed25519"
+	}
+
+	ip := getDevNodeIP(node)
+
+	sshArgs := []string{
+		"-i", sshKey,
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-t", // Force pseudo-terminal
+	}
+
+	// Add port forwarding
+	allPorts := append(devPorts, job.Ports...)
+	for _, p := range allPorts {
+		sshArgs = append(sshArgs, "-L", fmt.Sprintf("%d:localhost:%d", p, p))
+	}
+
+	sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", devSSHUser, ip))
+
+	// Start in workspace directory
+	sshArgs = append(sshArgs, "cd /workspace && exec $SHELL -l")
+
+	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Wait a moment for context cancellation to not immediately kill SSH
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Run()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		// Give SSH a moment to clean up
+		time.Sleep(100 * time.Millisecond)
+		return nil
+	}
+}

--- a/cmd/navarch/main.go
+++ b/cmd/navarch/main.go
@@ -37,6 +37,8 @@ func main() {
 	rootCmd.AddCommand(cordonCmd())
 	rootCmd.AddCommand(drainCmd())
 	rootCmd.AddCommand(uncordonCmd())
+	rootCmd.AddCommand(runCmd())
+	rootCmd.AddCommand(devCmd())
 	rootCmd.AddCommand(versionCmd())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/navarch/run.go
+++ b/cmd/navarch/run.go
@@ -1,0 +1,371 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	"github.com/NavarchProject/navarch/pkg/config"
+	"github.com/NavarchProject/navarch/pkg/sync"
+	pb "github.com/NavarchProject/navarch/proto"
+)
+
+var (
+	runConfigFile   string
+	runGPU          string
+	runPool         string
+	runCommand      string
+	runSSHKey       string
+	runSSHUser      string
+	runNoSync       bool
+	runWorkdir      string
+	runDetach       bool
+)
+
+func runCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run [command]",
+		Short: "Run a command on a GPU instance",
+		Long: `Run a command on a GPU instance from a pool.
+
+The command can be specified directly as arguments, or via a navarch.yaml config file.
+
+Examples:
+  # Run a command directly
+  navarch run python train.py --epochs 100
+
+  # Run from config file
+  navarch run -f navarch.yaml
+
+  # Run with specific GPU and pool
+  navarch run --gpu H100 --pool training python train.py`,
+		RunE: runTask,
+	}
+
+	cmd.Flags().StringVarP(&runConfigFile, "file", "f", "", "Config file (default: auto-detect navarch.yaml)")
+	cmd.Flags().StringVar(&runGPU, "gpu", "", "GPU type requirement (e.g., H100, A100:4)")
+	cmd.Flags().StringVar(&runPool, "pool", "", "Pool to use")
+	cmd.Flags().StringVar(&runCommand, "command", "", "Command to run (alternative to positional args)")
+	cmd.Flags().StringVar(&runSSHKey, "ssh-key", "", "SSH private key path")
+	cmd.Flags().StringVar(&runSSHUser, "ssh-user", "ubuntu", "SSH user")
+	cmd.Flags().BoolVar(&runNoSync, "no-sync", false, "Skip code sync")
+	cmd.Flags().StringVar(&runWorkdir, "workdir", ".", "Local directory to sync")
+	cmd.Flags().BoolVarP(&runDetach, "detach", "d", false, "Run in background (detached mode)")
+
+	return cmd
+}
+
+func runTask(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	// Load job config
+	jobCfg, err := loadJobConfig(args)
+	if err != nil {
+		return err
+	}
+
+	// Get a node to run on
+	node, err := selectNode(ctx, jobCfg)
+	if err != nil {
+		return fmt.Errorf("failed to select node: %w", err)
+	}
+
+	fmt.Printf("Selected node: %s (%s)\n", node.NodeId, getNodeIP(node))
+
+	// Sync code if not disabled
+	if !runNoSync {
+		fmt.Println("Syncing code...")
+		if err := syncCode(ctx, node, jobCfg); err != nil {
+			return fmt.Errorf("failed to sync code: %w", err)
+		}
+		fmt.Println("Code sync complete")
+	}
+
+	// Build and run the command
+	runCommand := buildCommand(jobCfg)
+	if runCommand == "" {
+		return fmt.Errorf("no command specified")
+	}
+
+	fmt.Printf("Running: %s\n", runCommand)
+	fmt.Println("---")
+
+	if runDetach {
+		return runDetached(ctx, node, jobCfg, runCommand)
+	}
+
+	return runAttached(ctx, node, jobCfg, runCommand)
+}
+
+func loadJobConfig(args []string) (*config.JobConfig, error) {
+	// Try to load from config file
+	if runConfigFile != "" {
+		return config.LoadJob(runConfigFile)
+	}
+
+	// Try auto-detect
+	configPath, err := config.FindJobConfig()
+	if err == nil {
+		job, err := config.LoadJob(configPath)
+		if err != nil {
+			return nil, err
+		}
+		// Override with CLI flags
+		applyFlags(job, args)
+		return job, nil
+	}
+
+	// Create job from CLI flags
+	job := &config.JobConfig{
+		WorkDir: runWorkdir,
+	}
+
+	if len(args) > 0 {
+		job.Run = strings.Join(args, " ")
+	} else if runCommand != "" {
+		job.Run = runCommand
+	}
+
+	if runGPU != "" {
+		job.Resources.GPU = runGPU
+	}
+
+	if runPool != "" {
+		job.Pool = runPool
+	}
+
+	return job, nil
+}
+
+func applyFlags(job *config.JobConfig, args []string) {
+	if runGPU != "" {
+		job.Resources.GPU = runGPU
+	}
+	if runPool != "" {
+		job.Pool = runPool
+	}
+	if runWorkdir != "." {
+		job.WorkDir = runWorkdir
+	}
+	if len(args) > 0 {
+		job.Run = strings.Join(args, " ")
+	}
+}
+
+func selectNode(ctx context.Context, job *config.JobConfig) (*pb.NodeInfo, error) {
+	client := newClient()
+
+	req := connect.NewRequest(&pb.ListNodesRequest{})
+	resp, err := client.ListNodes(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	if len(resp.Msg.Nodes) == 0 {
+		return nil, fmt.Errorf("no nodes available")
+	}
+
+	// Filter by pool if specified
+	var candidates []*pb.NodeInfo
+	for _, node := range resp.Msg.Nodes {
+		// Must be active
+		if node.Status != pb.NodeStatus_NODE_STATUS_ACTIVE {
+			continue
+		}
+
+		// Must have IP address
+		ip := getNodeIP(node)
+		if ip == "" {
+			continue
+		}
+
+		// Filter by pool if specified
+		if job.Pool != "" {
+			if node.Metadata == nil {
+				continue
+			}
+			poolLabel, ok := node.Metadata.Labels["pool"]
+			if !ok || poolLabel != job.Pool {
+				continue
+			}
+		}
+
+		// Filter by GPU type if specified
+		if job.Resources.GPU != "" {
+			gpuType, _ := job.Resources.ParseGPU()
+			if gpuType != "" && gpuType != "any" {
+				// Check if node has matching GPU
+				hasMatch := false
+				for _, gpu := range node.Gpus {
+					if strings.Contains(strings.ToUpper(gpu.Name), strings.ToUpper(gpuType)) {
+						hasMatch = true
+						break
+					}
+				}
+				if !hasMatch {
+					continue
+				}
+			}
+		}
+
+		candidates = append(candidates, node)
+	}
+
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no suitable nodes found (pool=%q, gpu=%q)", job.Pool, job.Resources.GPU)
+	}
+
+	// Return first available node
+	return candidates[0], nil
+}
+
+// getNodeIP returns the node's IP address (external preferred, internal fallback).
+func getNodeIP(node *pb.NodeInfo) string {
+	if node.Metadata == nil {
+		return ""
+	}
+	if node.Metadata.ExternalIp != "" {
+		return node.Metadata.ExternalIp
+	}
+	return node.Metadata.InternalIp
+}
+
+func syncCode(ctx context.Context, node *pb.NodeInfo, job *config.JobConfig) error {
+	sshKey := runSSHKey
+	if sshKey == "" {
+		// Try default SSH key locations
+		homeDir, _ := os.UserHomeDir()
+		candidates := []string{
+			homeDir + "/.ssh/id_ed25519",
+			homeDir + "/.ssh/id_rsa",
+		}
+		for _, path := range candidates {
+			if _, err := os.Stat(path); err == nil {
+				sshKey = path
+				break
+			}
+		}
+	}
+
+	if sshKey == "" {
+		return fmt.Errorf("no SSH key found, specify with --ssh-key")
+	}
+
+	workdir := job.WorkDir
+	if workdir == "" {
+		workdir = "."
+	}
+
+	// Resolve workdir to absolute path
+	if !strings.HasPrefix(workdir, "/") {
+		cwd, _ := os.Getwd()
+		workdir = cwd + "/" + workdir
+	}
+
+	port := 22
+	ip := getNodeIP(node)
+
+	return sync.SyncToNode(ctx, workdir, runSSHUser, ip, port, sshKey, "/workspace")
+}
+
+func buildCommand(job *config.JobConfig) string {
+	var parts []string
+
+	// Change to workspace directory
+	parts = append(parts, "cd /workspace")
+
+	// Setup commands
+	if job.Setup != "" {
+		parts = append(parts, job.Setup)
+	}
+
+	// Main run command
+	if job.Run != "" {
+		parts = append(parts, job.Run)
+	}
+
+	return strings.Join(parts, " && ")
+}
+
+func runAttached(ctx context.Context, node *pb.NodeInfo, job *config.JobConfig, command string) error {
+	sshKey := runSSHKey
+	if sshKey == "" {
+		homeDir, _ := os.UserHomeDir()
+		sshKey = homeDir + "/.ssh/id_ed25519"
+	}
+
+	port := 22
+	ip := getNodeIP(node)
+
+	// Build SSH command
+	sshArgs := []string{
+		"-i", sshKey,
+		"-p", fmt.Sprintf("%d", port),
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-t", // Force pseudo-terminal for interactive output
+		fmt.Sprintf("%s@%s", runSSHUser, ip),
+		command,
+	}
+
+	// Set environment variables
+	if len(job.Envs) > 0 {
+		var envPrefix []string
+		for k, v := range job.Envs {
+			envPrefix = append(envPrefix, fmt.Sprintf("%s=%s", k, v))
+		}
+		// Prepend env vars to command
+		sshArgs[len(sshArgs)-1] = strings.Join(envPrefix, " ") + " " + command
+	}
+
+	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}
+
+func runDetached(ctx context.Context, node *pb.NodeInfo, job *config.JobConfig, command string) error {
+	sshKey := runSSHKey
+	if sshKey == "" {
+		homeDir, _ := os.UserHomeDir()
+		sshKey = homeDir + "/.ssh/id_ed25519"
+	}
+
+	port := 22
+	ip := getNodeIP(node)
+
+	// Wrap command in nohup and redirect output
+	detachCmd := fmt.Sprintf("nohup bash -c '%s' > /workspace/output.log 2>&1 &", command)
+
+	sshArgs := []string{
+		"-i", sshKey,
+		"-p", fmt.Sprintf("%d", port),
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		fmt.Sprintf("%s@%s", runSSHUser, ip),
+		detachCmd,
+	}
+
+	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	fmt.Printf("\nTask running in background on %s\n", node.NodeId)
+	fmt.Println("Output: /workspace/output.log")
+	fmt.Printf("SSH: ssh -i %s %s@%s\n", sshKey, runSSHUser, ip)
+
+	return nil
+}

--- a/pkg/config/job.go
+++ b/pkg/config/job.go
@@ -1,0 +1,282 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// JobConfig defines a task or job to run on GPU instances.
+// Used by `navarch run` and `navarch dev` commands.
+type JobConfig struct {
+	// Name is an optional identifier for the job.
+	Name string `yaml:"name,omitempty"`
+
+	// Resources specifies GPU and compute requirements.
+	Resources ResourcesCfg `yaml:"resources,omitempty"`
+
+	// Run is the command or script to execute.
+	// Can be a single command string or multi-line script.
+	Run string `yaml:"run,omitempty"`
+
+	// Setup contains commands to run before the main task.
+	// Useful for installing dependencies, downloading data, etc.
+	Setup string `yaml:"setup,omitempty"`
+
+	// Envs are environment variables to set.
+	Envs map[string]string `yaml:"envs,omitempty"`
+
+	// WorkDir is the local directory to sync to the instance.
+	// Defaults to current directory.
+	WorkDir string `yaml:"workdir,omitempty"`
+
+	// Image is the Docker image to use.
+	// If not specified, runs on bare metal with system Python.
+	Image string `yaml:"image,omitempty"`
+
+	// Ports to expose (for dev mode).
+	Ports []int `yaml:"ports,omitempty"`
+
+	// Spot enables spot/preemptible instances for cost savings.
+	Spot bool `yaml:"spot,omitempty"`
+
+	// Pool specifies which pool to use (if multiple pools exist).
+	Pool string `yaml:"pool,omitempty"`
+}
+
+// ResourcesCfg specifies compute resource requirements.
+type ResourcesCfg struct {
+	// GPU specifies GPU requirements.
+	// Can be: "H100", "H100:8", "A100", "any", etc.
+	GPU string `yaml:"gpu,omitempty"`
+
+	// GPUCount specifies number of GPUs (alternative to GPU suffix).
+	GPUCount int `yaml:"gpu_count,omitempty"`
+
+	// Memory specifies minimum memory (e.g., "64GB").
+	Memory string `yaml:"memory,omitempty"`
+
+	// CPUs specifies minimum vCPUs.
+	CPUs int `yaml:"cpus,omitempty"`
+
+	// Cloud restricts to specific cloud provider(s).
+	// Can be: "aws", "gcp", "lambda", or comma-separated list.
+	Cloud string `yaml:"cloud,omitempty"`
+
+	// Region restricts to specific region(s).
+	Region string `yaml:"region,omitempty"`
+
+	// Zone restricts to specific zone(s).
+	Zone string `yaml:"zone,omitempty"`
+}
+
+// LoadJob reads a job configuration from a YAML file.
+func LoadJob(path string) (*JobConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading job config: %w", err)
+	}
+
+	var job JobConfig
+	if err := yaml.Unmarshal(data, &job); err != nil {
+		return nil, fmt.Errorf("parsing job config: %w", err)
+	}
+
+	if err := job.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid job config: %w", err)
+	}
+
+	job.applyDefaults()
+	return &job, nil
+}
+
+// LoadJobFromString parses a job configuration from YAML string.
+func LoadJobFromString(data string) (*JobConfig, error) {
+	var job JobConfig
+	if err := yaml.Unmarshal([]byte(data), &job); err != nil {
+		return nil, fmt.Errorf("parsing job config: %w", err)
+	}
+
+	if err := job.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid job config: %w", err)
+	}
+
+	job.applyDefaults()
+	return &job, nil
+}
+
+// Validate checks the job configuration for errors.
+func (j *JobConfig) Validate() error {
+	// At minimum, a job needs either a run command or to be a dev session
+	// (dev sessions don't require a run command since they're interactive)
+	// This validation is minimal - more validation happens at runtime
+
+	if j.Resources.GPU != "" {
+		if err := validateGPUSpec(j.Resources.GPU); err != nil {
+			return err
+		}
+	}
+
+	if j.Resources.Memory != "" {
+		if err := validateMemorySpec(j.Resources.Memory); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (j *JobConfig) applyDefaults() {
+	if j.WorkDir == "" {
+		j.WorkDir = "."
+	}
+}
+
+// ParseGPU parses a GPU specification string and returns GPU type and count.
+// Examples: "H100" -> ("H100", 1), "H100:8" -> ("H100", 8), "any:4" -> ("any", 4)
+func (r *ResourcesCfg) ParseGPU() (gpuType string, count int) {
+	if r.GPU == "" {
+		return "", r.GPUCount
+	}
+
+	parts := strings.SplitN(r.GPU, ":", 2)
+	gpuType = parts[0]
+	count = 1
+
+	if len(parts) == 2 {
+		fmt.Sscanf(parts[1], "%d", &count)
+	}
+
+	// GPUCount takes precedence if specified
+	if r.GPUCount > 0 {
+		count = r.GPUCount
+	}
+
+	return gpuType, count
+}
+
+// ParseMemoryGB parses memory specification and returns gigabytes.
+// Examples: "64GB" -> 64, "128G" -> 128, "256" -> 256
+func (r *ResourcesCfg) ParseMemoryGB() int {
+	if r.Memory == "" {
+		return 0
+	}
+
+	mem := strings.TrimSpace(strings.ToUpper(r.Memory))
+	mem = strings.TrimSuffix(mem, "GB")
+	mem = strings.TrimSuffix(mem, "G")
+
+	var gb int
+	fmt.Sscanf(mem, "%d", &gb)
+	return gb
+}
+
+// ParseClouds returns the list of allowed cloud providers.
+func (r *ResourcesCfg) ParseClouds() []string {
+	if r.Cloud == "" {
+		return nil
+	}
+
+	clouds := strings.Split(r.Cloud, ",")
+	for i := range clouds {
+		clouds[i] = strings.TrimSpace(strings.ToLower(clouds[i]))
+	}
+	return clouds
+}
+
+// ParseRegions returns the list of allowed regions.
+func (r *ResourcesCfg) ParseRegions() []string {
+	if r.Region == "" {
+		return nil
+	}
+
+	regions := strings.Split(r.Region, ",")
+	for i := range regions {
+		regions[i] = strings.TrimSpace(regions[i])
+	}
+	return regions
+}
+
+func validateGPUSpec(spec string) error {
+	parts := strings.SplitN(spec, ":", 2)
+	gpuType := strings.ToUpper(parts[0])
+
+	// Valid GPU types (common ones)
+	validTypes := map[string]bool{
+		"ANY":   true,
+		"H100":  true,
+		"A100":  true,
+		"A10G":  true,
+		"L4":    true,
+		"L40S":  true,
+		"V100":  true,
+		"T4":    true,
+		"A6000": true,
+		"RTX":   true, // Allow RTX* pattern
+	}
+
+	// Check if type is valid or starts with a valid prefix
+	if !validTypes[gpuType] && !strings.HasPrefix(gpuType, "RTX") {
+		// Allow unknown types with a warning (flexibility for new GPUs)
+	}
+
+	if len(parts) == 2 {
+		var count int
+		if _, err := fmt.Sscanf(parts[1], "%d", &count); err != nil || count <= 0 {
+			return fmt.Errorf("invalid GPU count in %q: must be positive integer", spec)
+		}
+	}
+
+	return nil
+}
+
+func validateMemorySpec(spec string) error {
+	mem := strings.TrimSpace(strings.ToUpper(spec))
+	mem = strings.TrimSuffix(mem, "GB")
+	mem = strings.TrimSuffix(mem, "G")
+
+	var gb int
+	if _, err := fmt.Sscanf(mem, "%d", &gb); err != nil || gb <= 0 {
+		return fmt.Errorf("invalid memory specification %q: must be positive integer with optional GB suffix", spec)
+	}
+
+	return nil
+}
+
+// FindJobConfig looks for a job configuration file in standard locations.
+// Checks: navarch.yaml, navarch.yml, .navarch.yaml, .navarch.yml
+func FindJobConfig() (string, error) {
+	candidates := []string{
+		"navarch.yaml",
+		"navarch.yml",
+		".navarch.yaml",
+		".navarch.yml",
+	}
+
+	for _, name := range candidates {
+		if _, err := os.Stat(name); err == nil {
+			return name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no job config found (tried: %s)", strings.Join(candidates, ", "))
+}
+
+// ResolveWorkDir resolves the workdir path relative to the config file.
+func (j *JobConfig) ResolveWorkDir(configPath string) (string, error) {
+	if filepath.IsAbs(j.WorkDir) {
+		return j.WorkDir, nil
+	}
+
+	// If config path is provided, resolve relative to it
+	if configPath != "" {
+		configDir := filepath.Dir(configPath)
+		return filepath.Join(configDir, j.WorkDir), nil
+	}
+
+	// Otherwise resolve relative to cwd
+	return filepath.Abs(j.WorkDir)
+}

--- a/pkg/config/job_test.go
+++ b/pkg/config/job_test.go
@@ -1,0 +1,317 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadJobFromString(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+		check   func(*testing.T, *JobConfig)
+	}{
+		{
+			name: "minimal config",
+			yaml: `
+run: python train.py
+`,
+			wantErr: false,
+			check: func(t *testing.T, j *JobConfig) {
+				if j.Run != "python train.py" {
+					t.Errorf("expected run='python train.py', got %q", j.Run)
+				}
+				if j.WorkDir != "." {
+					t.Errorf("expected default workdir='.', got %q", j.WorkDir)
+				}
+			},
+		},
+		{
+			name: "full config",
+			yaml: `
+name: training-job
+resources:
+  gpu: H100:8
+  memory: 128GB
+  cpus: 32
+  cloud: aws,gcp
+  region: us-east-1,us-west-2
+run: |
+  cd /workspace
+  python train.py --epochs 100
+setup: |
+  pip install -r requirements.txt
+envs:
+  WANDB_API_KEY: secret
+  CUDA_VISIBLE_DEVICES: "0,1,2,3"
+workdir: ./src
+image: pytorch/pytorch:2.0-cuda11.8
+ports:
+  - 8888
+  - 6006
+spot: true
+pool: training
+`,
+			wantErr: false,
+			check: func(t *testing.T, j *JobConfig) {
+				if j.Name != "training-job" {
+					t.Errorf("expected name='training-job', got %q", j.Name)
+				}
+				if j.Resources.GPU != "H100:8" {
+					t.Errorf("expected gpu='H100:8', got %q", j.Resources.GPU)
+				}
+				if j.Resources.Memory != "128GB" {
+					t.Errorf("expected memory='128GB', got %q", j.Resources.Memory)
+				}
+				if j.Resources.CPUs != 32 {
+					t.Errorf("expected cpus=32, got %d", j.Resources.CPUs)
+				}
+				if !j.Spot {
+					t.Error("expected spot=true")
+				}
+				if j.Pool != "training" {
+					t.Errorf("expected pool='training', got %q", j.Pool)
+				}
+				if len(j.Ports) != 2 {
+					t.Errorf("expected 2 ports, got %d", len(j.Ports))
+				}
+				if j.Image != "pytorch/pytorch:2.0-cuda11.8" {
+					t.Errorf("expected image='pytorch/pytorch:2.0-cuda11.8', got %q", j.Image)
+				}
+			},
+		},
+		{
+			name: "gpu count alternative",
+			yaml: `
+resources:
+  gpu: A100
+  gpu_count: 4
+run: python train.py
+`,
+			wantErr: false,
+			check: func(t *testing.T, j *JobConfig) {
+				gpuType, count := j.Resources.ParseGPU()
+				if gpuType != "A100" {
+					t.Errorf("expected gpu type='A100', got %q", gpuType)
+				}
+				if count != 4 {
+					t.Errorf("expected gpu count=4, got %d", count)
+				}
+			},
+		},
+		{
+			name: "invalid gpu count",
+			yaml: `
+resources:
+  gpu: H100:invalid
+run: test
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid memory",
+			yaml: `
+resources:
+  memory: invalid
+run: test
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job, err := LoadJobFromString(tt.yaml)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, job)
+			}
+		})
+	}
+}
+
+func TestResourcesCfg_ParseGPU(t *testing.T) {
+	tests := []struct {
+		gpu       string
+		gpuCount  int
+		wantType  string
+		wantCount int
+	}{
+		{"H100", 0, "H100", 1},
+		{"H100:8", 0, "H100", 8},
+		{"A100:4", 0, "A100", 4},
+		{"any", 0, "any", 1},
+		{"any:2", 0, "any", 2},
+		{"", 4, "", 4},
+		{"H100", 8, "H100", 8}, // GPUCount takes precedence
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.gpu, func(t *testing.T) {
+			r := ResourcesCfg{GPU: tt.gpu, GPUCount: tt.gpuCount}
+			gotType, gotCount := r.ParseGPU()
+			if gotType != tt.wantType {
+				t.Errorf("ParseGPU() type = %q, want %q", gotType, tt.wantType)
+			}
+			if gotCount != tt.wantCount {
+				t.Errorf("ParseGPU() count = %d, want %d", gotCount, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestResourcesCfg_ParseMemoryGB(t *testing.T) {
+	tests := []struct {
+		memory string
+		want   int
+	}{
+		{"64GB", 64},
+		{"128G", 128},
+		{"256", 256},
+		{"64gb", 64},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.memory, func(t *testing.T) {
+			r := ResourcesCfg{Memory: tt.memory}
+			if got := r.ParseMemoryGB(); got != tt.want {
+				t.Errorf("ParseMemoryGB() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourcesCfg_ParseClouds(t *testing.T) {
+	tests := []struct {
+		cloud string
+		want  []string
+	}{
+		{"aws", []string{"aws"}},
+		{"aws,gcp", []string{"aws", "gcp"}},
+		{"AWS, GCP, Lambda", []string{"aws", "gcp", "lambda"}},
+		{"", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cloud, func(t *testing.T) {
+			r := ResourcesCfg{Cloud: tt.cloud}
+			got := r.ParseClouds()
+			if len(got) != len(tt.want) {
+				t.Errorf("ParseClouds() = %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ParseClouds()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLoadJob(t *testing.T) {
+	// Create a temporary job config file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "navarch.yaml")
+
+	content := `
+name: test-job
+resources:
+  gpu: H100:4
+run: python train.py
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	job, err := LoadJob(configPath)
+	if err != nil {
+		t.Fatalf("LoadJob() error: %v", err)
+	}
+
+	if job.Name != "test-job" {
+		t.Errorf("expected name='test-job', got %q", job.Name)
+	}
+	if job.Resources.GPU != "H100:4" {
+		t.Errorf("expected gpu='H100:4', got %q", job.Resources.GPU)
+	}
+}
+
+func TestFindJobConfig(t *testing.T) {
+	// Save current dir and change to temp
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	// No config should fail
+	_, err := FindJobConfig()
+	if err == nil {
+		t.Error("expected error when no config exists")
+	}
+
+	// Create navarch.yaml
+	if err := os.WriteFile("navarch.yaml", []byte("run: test"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	path, err := FindJobConfig()
+	if err != nil {
+		t.Errorf("FindJobConfig() error: %v", err)
+	}
+	if path != "navarch.yaml" {
+		t.Errorf("FindJobConfig() = %q, want 'navarch.yaml'", path)
+	}
+}
+
+func TestJobConfig_ResolveWorkDir(t *testing.T) {
+	tests := []struct {
+		name       string
+		workDir    string
+		configPath string
+		wantSuffix string
+	}{
+		{
+			name:       "relative to config",
+			workDir:    "src",
+			configPath: "/home/user/project/navarch.yaml",
+			wantSuffix: "/home/user/project/src",
+		},
+		{
+			name:       "absolute path unchanged",
+			workDir:    "/absolute/path",
+			configPath: "/home/user/navarch.yaml",
+			wantSuffix: "/absolute/path",
+		},
+		{
+			name:       "current dir",
+			workDir:    ".",
+			configPath: "/home/user/navarch.yaml",
+			wantSuffix: "/home/user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := &JobConfig{WorkDir: tt.workDir}
+			got, err := j.ResolveWorkDir(tt.configPath)
+			if err != nil {
+				t.Fatalf("ResolveWorkDir() error: %v", err)
+			}
+			if got != tt.wantSuffix {
+				t.Errorf("ResolveWorkDir() = %q, want %q", got, tt.wantSuffix)
+			}
+		})
+	}
+}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -1,0 +1,203 @@
+// Package sync provides file synchronization between local and remote systems.
+package sync
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Options configures the sync operation.
+type Options struct {
+	// Source is the local directory to sync.
+	Source string
+
+	// Dest is the remote destination in format "user@host:path".
+	Dest string
+
+	// SSHKey is the path to the SSH private key.
+	SSHKey string
+
+	// SSHPort is the SSH port (default: 22).
+	SSHPort int
+
+	// Exclude patterns (gitignore-style).
+	Exclude []string
+
+	// Delete removes files on remote that don't exist locally.
+	Delete bool
+
+	// Verbose enables verbose output.
+	Verbose bool
+
+	// Stdout for command output (default: os.Stdout).
+	Stdout io.Writer
+
+	// Stderr for command errors (default: os.Stderr).
+	Stderr io.Writer
+}
+
+// Syncer synchronizes files to remote instances.
+type Syncer struct {
+	opts Options
+}
+
+// New creates a new Syncer with the given options.
+func New(opts Options) *Syncer {
+	if opts.SSHPort == 0 {
+		opts.SSHPort = 22
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	return &Syncer{opts: opts}
+}
+
+// Sync synchronizes the source directory to the remote destination.
+// Uses rsync if available, falls back to scp.
+func (s *Syncer) Sync(ctx context.Context) error {
+	// Prefer rsync for efficiency
+	if rsyncAvailable() {
+		return s.syncWithRsync(ctx)
+	}
+	return s.syncWithSCP(ctx)
+}
+
+func (s *Syncer) syncWithRsync(ctx context.Context) error {
+	args := []string{
+		"-avz",                   // archive, verbose, compress
+		"--progress",             // show progress
+		"-e", s.sshCommand(),     // use SSH with key
+	}
+
+	if s.opts.Delete {
+		args = append(args, "--delete")
+	}
+
+	// Add exclude patterns
+	for _, pattern := range s.opts.Exclude {
+		args = append(args, "--exclude", pattern)
+	}
+
+	// Add default excludes for common development artifacts
+	defaultExcludes := []string{
+		".git",
+		"__pycache__",
+		"*.pyc",
+		".pytest_cache",
+		"node_modules",
+		".venv",
+		"venv",
+		".env",
+		"*.egg-info",
+		".tox",
+		".mypy_cache",
+		".ruff_cache",
+	}
+	for _, pattern := range defaultExcludes {
+		args = append(args, "--exclude", pattern)
+	}
+
+	// Ensure source ends with / to sync contents (not directory itself)
+	source := s.opts.Source
+	if !strings.HasSuffix(source, "/") {
+		source += "/"
+	}
+
+	args = append(args, source, s.opts.Dest)
+
+	cmd := exec.CommandContext(ctx, "rsync", args...)
+	cmd.Stdout = s.opts.Stdout
+	cmd.Stderr = s.opts.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("rsync failed: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Syncer) syncWithSCP(ctx context.Context) error {
+	// SCP fallback for systems without rsync
+	args := []string{
+		"-r",                     // recursive
+		"-i", s.opts.SSHKey,      // identity file
+		"-P", fmt.Sprintf("%d", s.opts.SSHPort),
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+	}
+
+	args = append(args, s.opts.Source, s.opts.Dest)
+
+	cmd := exec.CommandContext(ctx, "scp", args...)
+	cmd.Stdout = s.opts.Stdout
+	cmd.Stderr = s.opts.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("scp failed: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Syncer) sshCommand() string {
+	return fmt.Sprintf("ssh -i %s -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+		s.opts.SSHKey, s.opts.SSHPort)
+}
+
+func rsyncAvailable() bool {
+	_, err := exec.LookPath("rsync")
+	return err == nil
+}
+
+// SyncToNode is a convenience function to sync files to a Navarch node.
+func SyncToNode(ctx context.Context, localDir, user, host string, port int, sshKey, remotePath string) error {
+	if remotePath == "" {
+		remotePath = "/workspace"
+	}
+
+	// Ensure local directory exists
+	if _, err := os.Stat(localDir); err != nil {
+		return fmt.Errorf("source directory does not exist: %w", err)
+	}
+
+	// Resolve to absolute path
+	absPath, err := filepath.Abs(localDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	syncer := New(Options{
+		Source:  absPath,
+		Dest:    fmt.Sprintf("%s@%s:%s", user, host, remotePath),
+		SSHKey:  sshKey,
+		SSHPort: port,
+		Delete:  true,
+		Verbose: true,
+	})
+
+	return syncer.Sync(ctx)
+}
+
+// WatchAndSync watches the source directory and syncs changes.
+// This is useful for development mode where you want live updates.
+func (s *Syncer) WatchAndSync(ctx context.Context, onChange func()) error {
+	// For initial implementation, we do a simple initial sync
+	// TODO: Add file watcher (fsnotify) for live sync in dev mode
+	if err := s.Sync(ctx); err != nil {
+		return err
+	}
+
+	if onChange != nil {
+		onChange()
+	}
+
+	return nil
+}

--- a/pkg/sync/sync_test.go
+++ b/pkg/sync/sync_test.go
@@ -1,0 +1,135 @@
+package sync
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	opts := Options{
+		Source:  "/local/path",
+		Dest:    "user@host:/remote/path",
+		SSHKey:  "/path/to/key",
+		SSHPort: 2222,
+	}
+
+	s := New(opts)
+	if s.opts.SSHPort != 2222 {
+		t.Errorf("expected SSHPort=2222, got %d", s.opts.SSHPort)
+	}
+}
+
+func TestNew_Defaults(t *testing.T) {
+	s := New(Options{})
+
+	if s.opts.SSHPort != 22 {
+		t.Errorf("expected default SSHPort=22, got %d", s.opts.SSHPort)
+	}
+	if s.opts.Stdout == nil {
+		t.Error("expected default Stdout")
+	}
+	if s.opts.Stderr == nil {
+		t.Error("expected default Stderr")
+	}
+}
+
+func TestSyncer_sshCommand(t *testing.T) {
+	s := New(Options{
+		SSHKey:  "/home/user/.ssh/id_rsa",
+		SSHPort: 2222,
+	})
+
+	cmd := s.sshCommand()
+	if !strings.Contains(cmd, "-i /home/user/.ssh/id_rsa") {
+		t.Error("SSH command should contain key path")
+	}
+	if !strings.Contains(cmd, "-p 2222") {
+		t.Error("SSH command should contain port")
+	}
+	if !strings.Contains(cmd, "StrictHostKeyChecking=no") {
+		t.Error("SSH command should disable strict host key checking")
+	}
+}
+
+func TestRsyncAvailable(t *testing.T) {
+	// This test just checks that the function doesn't panic
+	// The result depends on the system
+	_ = rsyncAvailable()
+}
+
+func TestSyncToNode_InvalidSource(t *testing.T) {
+	ctx := context.Background()
+	err := SyncToNode(ctx, "/nonexistent/path", "user", "host", 22, "/key", "/workspace")
+	if err == nil {
+		t.Error("expected error for nonexistent source")
+	}
+	if !strings.Contains(err.Error(), "source directory does not exist") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSyncToNode_DefaultRemotePath(t *testing.T) {
+	// Create a temp directory for the source
+	tmpDir := t.TempDir()
+
+	// This will fail because we can't actually SSH, but we're testing
+	// that the function sets up the syncer correctly
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately so we don't actually try to sync
+
+	// The error will be about the cancelled context or SSH failure,
+	// not about the remote path
+	_ = SyncToNode(ctx, tmpDir, "user", "host", 22, "/fake/key", "")
+}
+
+func TestSyncer_OutputCapture(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	s := New(Options{
+		Source:  "/local",
+		Dest:    "user@host:/remote",
+		SSHKey:  "/key",
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	})
+
+	if s.opts.Stdout != &stdout {
+		t.Error("stdout not captured correctly")
+	}
+	if s.opts.Stderr != &stderr {
+		t.Error("stderr not captured correctly")
+	}
+}
+
+func TestOptions_Exclude(t *testing.T) {
+	s := New(Options{
+		Source:  "/local",
+		Dest:    "user@host:/remote",
+		SSHKey:  "/key",
+		Exclude: []string{"*.log", "tmp/"},
+	})
+
+	if len(s.opts.Exclude) != 2 {
+		t.Errorf("expected 2 exclude patterns, got %d", len(s.opts.Exclude))
+	}
+}
+
+func TestSyncToNode_ResolvesPath(t *testing.T) {
+	// Create a temp directory
+	tmpDir := t.TempDir()
+
+	// Create a subdirectory to test relative path resolution
+	subDir := filepath.Join(tmpDir, "subdir")
+	os.Mkdir(subDir, 0755)
+
+	// Test that we can resolve the path (even though sync will fail)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// This should not error on path resolution
+	_ = SyncToNode(ctx, subDir, "user", "host", 22, "/fake/key", "/workspace")
+}


### PR DESCRIPTION
## Summary

Implement `navarch dev` command for interactive GPU development sessions.

## Features

- **Interactive SSH**: Opens shell session in /workspace
- **Code Sync**: rsync local directory to remote before starting
- **Setup Commands**: Run setup script before opening shell
- **Port Forwarding**: Forward ports for Jupyter, TensorBoard, etc.
- **Node Selection**: Filter by pool name and GPU type
- **Graceful Shutdown**: Clean exit on Ctrl+C

## Usage

```bash
# Start dev session with auto-detected config
navarch dev

# With port forwarding for Jupyter and TensorBoard
navarch dev --port 8888 --port 6006

# On specific pool with GPU
navarch dev --pool training --gpu H100

# Skip code sync
navarch dev --no-sync
```

## Example Session

```
$ navarch dev --port 8888
Selected node: node-abc123 (10.0.0.5)
Syncing code...
Code sync complete
Running setup...
Setup complete
---
Working directory: /workspace
Port forwarding:
  localhost:8888 -> 10.0.0.5:8888
---
Starting interactive session (Ctrl+D or 'exit' to close)

ubuntu@gpu-instance:~$ jupyter lab
```

## Dependencies

This PR includes run command (PR #39) and its dependencies.

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [ ] Manual test: navarch dev with live pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)