### PR TITLE
Add navarch ssh and logs commands

### DIFF
--- a/cmd/navarch/logs.go
+++ b/cmd/navarch/logs.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	logsUser   string
+	logsKey    string
+	logsFollow bool
+	logsTail   int
+	logsPath   string
+)
+
+func logsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs <node-id>",
+		Short: "View logs from a GPU node",
+		Long: `Fetch and display logs from a GPU node.
+
+By default, shows the task output log at /workspace/output.log (created by
+detached runs). Use --path to specify a different log file.
+
+Examples:
+  # View task output
+  navarch logs node-abc123
+
+  # Follow logs (like tail -f)
+  navarch logs -f node-abc123
+
+  # View last 100 lines
+  navarch logs --tail 100 node-abc123
+
+  # View a specific log file
+  navarch logs node-abc123 --path /var/log/syslog`,
+		Args: cobra.ExactArgs(1),
+		RunE: runLogs,
+	}
+
+	cmd.Flags().StringVarP(&logsUser, "user", "u", "ubuntu", "SSH user")
+	cmd.Flags().StringVarP(&logsKey, "identity", "i", "", "SSH private key path")
+	cmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "Follow log output")
+	cmd.Flags().IntVar(&logsTail, "tail", 0, "Number of lines to show from end (0 = all)")
+	cmd.Flags().StringVar(&logsPath, "path", "/workspace/output.log", "Log file path on remote")
+
+	return cmd
+}
+
+func runLogs(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	nodeIDPrefix := args[0]
+
+	// Find the node
+	node, err := findNode(ctx, nodeIDPrefix)
+	if err != nil {
+		return err
+	}
+
+	ip := getSSHNodeIP(node)
+	if ip == "" {
+		return fmt.Errorf("node %s has no IP address", node.NodeId)
+	}
+
+	// Find SSH key if not specified
+	keyPath := logsKey
+	if keyPath == "" {
+		homeDir, _ := os.UserHomeDir()
+		candidates := []string{
+			homeDir + "/.ssh/id_ed25519",
+			homeDir + "/.ssh/id_rsa",
+		}
+		for _, path := range candidates {
+			if _, err := os.Stat(path); err == nil {
+				keyPath = path
+				break
+			}
+		}
+	}
+
+	// Build remote command
+	var remoteCmd string
+	if logsFollow {
+		remoteCmd = fmt.Sprintf("tail -f %s", logsPath)
+	} else if logsTail > 0 {
+		remoteCmd = fmt.Sprintf("tail -n %d %s", logsTail, logsPath)
+	} else {
+		remoteCmd = fmt.Sprintf("cat %s", logsPath)
+	}
+
+	// Build SSH args
+	sshArgs := []string{
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+	}
+
+	if keyPath != "" {
+		sshArgs = append(sshArgs, "-i", keyPath)
+	}
+
+	sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", logsUser, ip), remoteCmd)
+
+	sshExec := exec.Command("ssh", sshArgs...)
+	sshExec.Stdout = os.Stdout
+	sshExec.Stderr = os.Stderr
+
+	// For follow mode, handle interrupt
+	if logsFollow {
+		sshExec.Stdin = os.Stdin
+	}
+
+	return sshExec.Run()
+}

--- a/cmd/navarch/main.go
+++ b/cmd/navarch/main.go
@@ -37,6 +37,8 @@ func main() {
 	rootCmd.AddCommand(cordonCmd())
 	rootCmd.AddCommand(drainCmd())
 	rootCmd.AddCommand(uncordonCmd())
+	rootCmd.AddCommand(sshCmd())
+	rootCmd.AddCommand(logsCmd())
 	rootCmd.AddCommand(versionCmd())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/navarch/ssh.go
+++ b/cmd/navarch/ssh.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/spf13/cobra"
+
+	pb "github.com/NavarchProject/navarch/proto"
+)
+
+var (
+	sshUser    string
+	sshKey     string
+	sshCommand string
+	sshPorts   []int
+)
+
+func sshCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ssh <node-id>",
+		Short: "SSH into a GPU node",
+		Long: `Open an SSH session to a GPU node.
+
+The node ID can be partial - it will match the first node that starts with the
+given prefix.
+
+Examples:
+  # SSH to a node
+  navarch ssh node-abc123
+
+  # SSH with partial ID
+  navarch ssh node-abc
+
+  # Run a command
+  navarch ssh node-abc -- nvidia-smi
+
+  # Forward ports
+  navarch ssh node-abc -p 8888 -p 6006`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: runSSH,
+	}
+
+	cmd.Flags().StringVarP(&sshUser, "user", "u", "ubuntu", "SSH user")
+	cmd.Flags().StringVarP(&sshKey, "identity", "i", "", "SSH private key path")
+	cmd.Flags().StringVarP(&sshCommand, "command", "c", "", "Command to run instead of shell")
+	cmd.Flags().IntSliceVarP(&sshPorts, "port", "p", nil, "Ports to forward (can be specified multiple times)")
+
+	return cmd
+}
+
+func runSSH(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	nodeIDPrefix := args[0]
+
+	// Find the node
+	node, err := findNode(ctx, nodeIDPrefix)
+	if err != nil {
+		return err
+	}
+
+	ip := getSSHNodeIP(node)
+	if ip == "" {
+		return fmt.Errorf("node %s has no IP address", node.NodeId)
+	}
+
+	fmt.Printf("Connecting to %s (%s)...\n", node.NodeId, ip)
+
+	// Find SSH key if not specified
+	keyPath := sshKey
+	if keyPath == "" {
+		homeDir, _ := os.UserHomeDir()
+		candidates := []string{
+			homeDir + "/.ssh/id_ed25519",
+			homeDir + "/.ssh/id_rsa",
+		}
+		for _, path := range candidates {
+			if _, err := os.Stat(path); err == nil {
+				keyPath = path
+				break
+			}
+		}
+	}
+
+	// Build SSH args
+	sshArgs := []string{
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+	}
+
+	if keyPath != "" {
+		sshArgs = append(sshArgs, "-i", keyPath)
+	}
+
+	// Add port forwarding
+	for _, p := range sshPorts {
+		sshArgs = append(sshArgs, "-L", fmt.Sprintf("%d:localhost:%d", p, p))
+	}
+
+	// Add user@host
+	sshArgs = append(sshArgs, fmt.Sprintf("%s@%s", sshUser, ip))
+
+	// Add command if specified (from flag or remaining args)
+	remoteCmd := sshCommand
+	if remoteCmd == "" && len(args) > 1 {
+		// Check if there's a -- separator
+		for i, arg := range args {
+			if arg == "--" {
+				remoteCmd = strings.Join(args[i+1:], " ")
+				break
+			}
+		}
+	}
+
+	if remoteCmd != "" {
+		sshArgs = append(sshArgs, remoteCmd)
+	} else {
+		// Interactive session needs -t
+		sshArgs = append([]string{"-t"}, sshArgs...)
+	}
+
+	sshExec := exec.Command("ssh", sshArgs...)
+	sshExec.Stdin = os.Stdin
+	sshExec.Stdout = os.Stdout
+	sshExec.Stderr = os.Stderr
+
+	return sshExec.Run()
+}
+
+func findNode(ctx context.Context, idPrefix string) (*pb.NodeInfo, error) {
+	client := newClient()
+
+	req := connect.NewRequest(&pb.ListNodesRequest{})
+	resp, err := client.ListNodes(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	// Find matching nodes
+	var matches []*pb.NodeInfo
+	for _, node := range resp.Msg.Nodes {
+		if strings.HasPrefix(node.NodeId, idPrefix) {
+			matches = append(matches, node)
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no node found matching %q", idPrefix)
+	}
+
+	if len(matches) > 1 {
+		var nodeIDs []string
+		for _, n := range matches {
+			nodeIDs = append(nodeIDs, n.NodeId)
+		}
+		return nil, fmt.Errorf("multiple nodes match %q: %s", idPrefix, strings.Join(nodeIDs, ", "))
+	}
+
+	return matches[0], nil
+}
+
+func getSSHNodeIP(node *pb.NodeInfo) string {
+	if node.Metadata == nil {
+		return ""
+	}
+	if node.Metadata.ExternalIp != "" {
+		return node.Metadata.ExternalIp
+	}
+	return node.Metadata.InternalIp
+}


### PR DESCRIPTION
## Summary

Add SSH and log viewing commands for GPU nodes.

## Commands

### navarch ssh

Quick SSH access to any node:

```bash
# SSH to a node (full or partial ID)
navarch ssh node-abc123
navarch ssh node-abc  # prefix matching

# Run a command
navarch ssh node-abc -- nvidia-smi

# Forward ports
navarch ssh node-abc -p 8888 -p 6006
```

### navarch logs

View logs from nodes:

```bash
# View task output log
navarch logs node-abc

# Follow logs (like tail -f)
navarch logs -f node-abc

# View last 100 lines
navarch logs --tail 100 node-abc

# View a different log file
navarch logs node-abc --path /var/log/syslog
```

## Features

- **Partial ID matching**: `navarch ssh node-abc` matches `node-abc123`
- **Port forwarding**: Forward multiple ports with `-p`
- **Follow mode**: Real-time log streaming with `-f`
- **Auto SSH key detection**: Tries ~/.ssh/id_ed25519, ~/.ssh/id_rsa

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [ ] Manual test: navarch ssh to live node
- [ ] Manual test: navarch logs from running task

🤖 Generated with [Claude Code](https://claude.com/claude-code)